### PR TITLE
Implementing session instance numbers

### DIFF
--- a/NK2Tray/Assignment.cs
+++ b/NK2Tray/Assignment.cs
@@ -21,6 +21,7 @@ namespace NK2Tray
         public int fader;
         public String sessionIdentifier;
         public String instanceIdentifier;
+        public int instanceNumber;
         public AssignmentType aType;
         public AudioSessionControl audioSession;
         public bool assigned = false;
@@ -31,16 +32,38 @@ namespace NK2Tray
         public Assignment(object sender)
         {
             //Assignment from MenuItem Tag
-            processName = (String)((object[])((MenuItem)sender).Tag)[0];
-            windowName = (String)((object[])((MenuItem)sender).Tag)[1];
-            pid = (int)((object[])((MenuItem)sender).Tag)[2];
-            fader = (int)((object[])((MenuItem)sender).Tag)[3];
-            aType = pid >= 0 ? AssignmentType.Process : AssignmentType.Master;
-            sessionIdentifier = (String)((object[])((MenuItem)sender).Tag)[4];
-            instanceIdentifier = (String)((object[])((MenuItem)sender).Tag)[5];
-            audioSession = (AudioSessionControl)((object[])((MenuItem)sender).Tag)[6];
-            session_alive = true;
-            assigned = true;
+            if (((object[])((MenuItem)sender).Tag).Count() == 1)
+            {
+                processName = "Master Volume";
+                windowName = "";
+                pid = -1;
+                fader = (int)((object[])((MenuItem)sender).Tag)[0];
+                aType = AssignmentType.Master;
+                sessionIdentifier = "";
+                instanceIdentifier = "";
+                instanceNumber = 0;
+                audioSession = null;
+                session_alive = true;
+                assigned = true;
+            }
+            else if (((object[])((MenuItem)sender).Tag).Count() == 2)
+            {
+                SessionAndMeta sessionMeta = (SessionAndMeta)((object[])((MenuItem)sender).Tag)[0];
+                fader = (int)((object[])((MenuItem)sender).Tag)[1];
+                audioSession = sessionMeta.session;
+                pid = (int)audioSession.GetProcessID;
+                Process process = Process.GetProcessById(pid);
+
+                processName = process.ProcessName;
+                windowName = process.MainWindowTitle;
+
+                aType = pid >= 0 ? AssignmentType.Process : AssignmentType.Master;
+                sessionIdentifier = audioSession.GetSessionIdentifier;
+                instanceIdentifier = audioSession.GetSessionInstanceIdentifier;
+                instanceNumber = sessionMeta.instanceNumber;
+                session_alive = true;
+                assigned = true;
+            }
         }
 
         public Assignment(AudioSessionControl session, int f)
@@ -53,6 +76,7 @@ namespace NK2Tray
             aType = AssignmentType.Process;
             sessionIdentifier = session.GetSessionIdentifier;
             instanceIdentifier = session.GetSessionInstanceIdentifier;
+            instanceNumber = 0;
             audioSession = session;
             session_alive = true;
             assigned = true;
@@ -67,6 +91,7 @@ namespace NK2Tray
             aType = AssignmentType.Process;
             sessionIdentifier = ident;
             instanceIdentifier = "";
+            instanceNumber = 0;
             audioSession = null;
             session_alive = false;
             assigned = true;
@@ -80,6 +105,7 @@ namespace NK2Tray
             aType = at;
             sessionIdentifier = sid;
             instanceIdentifier = iid;
+            instanceNumber = 0;
             audioSession = audsess;
             session_alive = true;
             assigned = true;

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -68,6 +68,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SessionAndMeta.cs" />
     <Compile Include="WindowTools.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/NK2Tray/SessionAndMeta.cs
+++ b/NK2Tray/SessionAndMeta.cs
@@ -1,0 +1,55 @@
+﻿using NAudio.CoreAudioApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NK2Tray
+{
+    public struct SessionAndMeta
+    {
+        public AudioSessionControl session;
+        public bool duplicate;
+        public int instanceNumber;
+
+        public SessionAndMeta(AudioSessionControl s, bool d, int i)
+        {
+            session = s;
+            duplicate = d;
+            instanceNumber = i;
+        }
+    }
+
+    public class SessionProcessor
+    {
+        public static List<SessionAndMeta> GetSessionMeta(ref SessionCollection sessions)
+        {
+            var outSessions = new List<SessionAndMeta>();
+            var sessionsByIdent = new Dictionary<String, List<AudioSessionControl>>();
+
+            Console.WriteLine("Getting sessions grouped by ident");
+            for (int i = 0; i < sessions.Count; i++)
+            {
+                var session = sessions[i];
+                if (!sessionsByIdent.ContainsKey(session.GetSessionIdentifier))
+                    sessionsByIdent[session.GetSessionIdentifier] = new List<AudioSessionControl>();
+                sessionsByIdent[session.GetSessionIdentifier].Add(session);
+            }
+            Console.WriteLine("Done!");
+
+            Console.WriteLine("Building SessionAndMeta for each");
+            foreach (var ident in sessionsByIdent.Keys.ToList())
+            {
+                Console.WriteLine("Working on " + ident);
+                var ordered = sessionsByIdent[ident].OrderBy(i => i.GetSessionInstanceIdentifier.Split('|').Last().Split('b').Last()).ToList();
+                bool dup = ordered.Count > 1;
+                for (int i = 0; i < ordered.Count; i++)
+                {
+                    outSessions.Add(new SessionAndMeta(ordered[i], dup, i));
+                    Console.WriteLine("" + i + ordered[i].GetSessionInstanceIdentifier);
+                }
+            }
+
+            return outSessions;
+        }
+    }
+}


### PR DESCRIPTION
for lack of a better way to handle this for now. The idea is that session instance identifiers seem to be somewhat stably ordered for multiple sessions. We could find other ways to solve this specifically for discord, but I hate that they are far less generic.