### PR TITLE
catch exception that leads to crash

### DIFF
--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -78,6 +78,11 @@ namespace NK2Tray
                     deviceVolume.MasterVolumeLevelScalar = volume;
                     Console.WriteLine($@"RETRY: Setting master volume to {volume}");
                 }
+                catch (System.Runtime.InteropServices.COMException e)
+                {
+                    //TODO find out where this exception comes from and actually fix it
+                    Console.WriteLine("COM Execption" + e);
+                }
             }
         }
 


### PR DESCRIPTION
for now simply catch the exception. This is most likeley not an ideal soulution but from my testing it worked pretty well. We still need to find the source of this exception and actually fix ist since in testing it got stuck once always trowing the exception until i restarted the program.