### PR TITLE
prvent crashing when no midi device is found

### DIFF
--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -29,6 +29,11 @@ namespace NK2Tray
 
             trayIcon.Visible = true;
 
+            SetupDevice();
+        }
+
+        private Boolean SetupDevice()
+        {
             audioDevice = new AudioDevice();
 
             midiDevice = new NanoKontrol2(audioDevice);
@@ -36,6 +41,8 @@ namespace NK2Tray
                 midiDevice = new XtouchMini(audioDevice);
 
             audioDevice.midiDevice = midiDevice;
+
+            return midiDevice.Found;
         }
 
         private void UnhandledExceptionTrapper(object sender, UnhandledExceptionEventArgs e)
@@ -65,6 +72,16 @@ namespace NK2Tray
 
             var mixerSessions = audioDevice.GetMixerSessions();
             var masterMixerSession = new MixerSession(audioDevice, "Master", SessionType.Master, audioDevice.GetDeviceVolumeObject());
+
+            // Dont create context menu if no midi device is connected
+            if(!midiDevice.Found)
+            {
+                if (!SetupDevice()) // This setup call can be removed once proper lifecycle management is implemented, for now this also adds a nice way to reconnect the controller
+                {
+                    MessageBox.Show("No midi device detected. Are you sure your device is plugged in correctly ?");
+                    return;
+                }
+            }
 
             foreach (var fader in midiDevice.faders)
             {


### PR DESCRIPTION
when no midi device is plugged in the application currently just crashes and gives no information for a reason. with this PR a popup warning is shown and the program tries to connect to a midi device whenever the context menu is opened and there was no device found at previous attemts.

This is not a full lifecycle management which is definitly needed (as mentioned in #5) but at least helps people who want to try out the program without a controller attatched so that they know whats up.