### PR TITLE
Improved finding mixer sessions for process ID's

### DIFF
--- a/NK2Tray/AudioDevice.cs
+++ b/NK2Tray/AudioDevice.cs
@@ -151,6 +151,18 @@ namespace NK2Tray
                     if (session.GetProcessID == pid)
                         return mixerSession;
 
+            // if mixer session was not found becuase the pid does not match the pid of any audio session try finding it by process name
+            // this is necessary since chrome and some other applications have some weired process structure
+            Process process = Process.GetProcessById(pid);
+
+            foreach (var mixerSession in mixerSessions)
+            {
+                if (mixerSession.label.Equals(process.ProcessName))
+                {
+                    return mixerSession;
+                }
+            }
+
             return null;
         }
     }

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -215,14 +215,16 @@ namespace NK2Tray
                 if (GetValue(e.MidiEvent) != 127) // Only on button-down
                     return true;
 
-                Console.WriteLine($@"Attempting to assign current window to fader {faderNumber}");
+                
                 if (assigned)
                 {
+                    Console.WriteLine($@"Unassigned fader {faderNumber}");
                     Unassign();
                     parent.SaveAssignments();
                 }
                 else
                 {
+                    Console.WriteLine($@"Attempting to assign current window to fader {faderNumber}");
                     var pid = WindowTools.GetForegroundPID();
                     var mixerSession = parent.audioDevice.FindMixerSessions(pid);
                     if (mixerSession != null)

--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -13,6 +13,9 @@ namespace NK2Tray
         Master
     }
 
+    /// <summary>
+    /// A <c>MixerSession</c> represents a running application and all audio sessions belonging to it.
+    /// </summary>
     public class MixerSession
     {
         public string label;


### PR DESCRIPTION
Fixes #27 

Certain programs like chrome (and therefor also many electron applications) use many different sub-processes with different process ids. Since the pid of the focused window is not always contained in the audio sessions of a mixer session this PR adds an additional step of trying to match pids to mixer sessions by comparing the process name. 

This works with my NK2 board and setup, i am not sure if this can have any undesired consequences, the only one i can think of if there are multiple mixer sessions from the same program but i do not know if that is possible ?