### PR TITLE
Multiple device support

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -69,7 +69,7 @@ namespace NK2Tray
         public string identifier;
         public string applicationPath;
         public string applicationName;
-        
+
         public Fader(MidiDevice midiDevice, int faderNum)
         {
             parent = midiDevice;
@@ -126,6 +126,7 @@ namespace NK2Tray
             assigned = false;
             assignment = null;
             SetSelectLight(false);
+            SetRecordLight(false);
             identifier = "";
             if (faderDef.delta)
                 parent.SetVolumeIndicator(faderNumber, -1);
@@ -133,7 +134,7 @@ namespace NK2Tray
 
         private void convertToApplicationPath(string ident)
         {
-            if (ident != null && ident != "" && !ident.Substring(0,Math.Min(10,ident.Length)).Equals("__MASTER__") && ident != "__FOCUS__") // TODO cleaner handling of special fader types
+            if (ident != null && ident != "" && !ident.Substring(0, Math.Min(10, ident.Length)).Equals("__MASTER__") && ident != "__FOCUS__") // TODO cleaner handling of special fader types
             {
                 //"{0.0.0.00000000}.{...}|\\Device\\HarddiskVolume8\\Users\\Dr. Locke\\AppData\\Roaming\\Spotify\\Spotify.exe%b{00000000-0000-0000-0000-000000000000}"
                 int deviceIndex = ident.IndexOf("\\Device");
@@ -223,7 +224,7 @@ namespace NK2Tray
                 SetHandling(true);
 
                 //if loaded inactive, search again
-                if (!assigned && identifier!=null && !identifier.Equals(""))
+                if (!assigned && identifier != null && !identifier.Equals(""))
                 {
                     assignment = parent.audioDevices.FindMixerSession(identifier);
                     if (assignment != null)
@@ -231,13 +232,21 @@ namespace NK2Tray
                         assigned = true;
                     }
                 }
-                                
+
                 // Fader match
                 if (assigned && Match(faderNumber, e.MidiEvent, faderDef.faderCode, faderDef.faderOffset, faderDef.faderChannelOverride))
                 {
                     if (assignment.sessionType == SessionType.Application)
-                        assignment = assignment.devices.FindMixerSession(assignment.sessionIdentifier); //update list for re-routered app
-                                        
+                    {
+                        MixerSession newAssignment = assignment.devices.FindMixerSession(assignment.sessionIdentifier); //update list for re-routered app, but only overrides
+                        if (newAssignment == null)                                                                      //if there is new assignments, otherwise, there is no more a inactive
+                        {                                                                                               //MixerSession to hold the label
+                            SetRecordLight(true);
+                            return true;
+                        }
+                        assignment = newAssignment;
+                    }
+
                     if (faderDef.delta)
                     {
                         float curVol;
@@ -255,7 +264,7 @@ namespace NK2Tray
 
                     if (assignment.IsDead())
                         SetRecordLight(true);
-                       
+
                     return true;
                 }
 

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -226,7 +226,7 @@ namespace NK2Tray
                 {
                     Console.WriteLine($@"Attempting to assign current window to fader {faderNumber}");
                     var pid = WindowTools.GetForegroundPID();
-                    var mixerSession = parent.audioDevice.FindMixerSessions(pid);
+                    var mixerSession = parent.audioDevices.FindMixerSessions(pid);
                     if (mixerSession != null)
                     {
                         Assign(mixerSession);

--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -33,7 +33,7 @@ namespace NK2Tray
             sessionIdentifier = identifier;
             audioSessions = sessions;
             sessionType = sesType;
-            label = devices.GetDeviceByIdentifier(identifier).FriendlyName + ": " + labl;
+            label = labl;
         }
 
         public MixerSession(String deviceIdentifier, AudioDevice devices, string labl, SessionType sesType)

--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -23,26 +23,28 @@ namespace NK2Tray
         public string sessionIdentifier;
         public List<AudioSessionControl> audioSessions;
         public SessionType sessionType;
-        public AudioEndpointVolume deviceVolume;
-        public AudioDevice parent;
+        public AudioDevice devices;
+        public String parentDeviceIdentifier;
 
-        public MixerSession(AudioDevice audioDev, string labl, string identifier, List<AudioSessionControl> sessions, SessionType sesType)
+        public MixerSession(AudioDevice devices, string labl, string identifier, List<AudioSessionControl> sessions, SessionType sesType)
         {
-            parent = audioDev;
-            label = labl;
+            this.devices = devices;
+   
             sessionIdentifier = identifier;
             audioSessions = sessions;
             sessionType = sesType;
+            label = devices.GetDeviceByIdentifier(identifier).FriendlyName + ": " + labl;
         }
 
-        public MixerSession(AudioDevice audioDev, string labl, SessionType sesType, AudioEndpointVolume devVol)
+        public MixerSession(String deviceIdentifier, AudioDevice devices, string labl, SessionType sesType)
         {
-            parent = audioDev;
-            label = labl;
+            this.devices = devices;
+            
             sessionIdentifier = "";
             audioSessions = new List<AudioSessionControl>();
             sessionType = sesType;
-            deviceVolume = devVol;
+            parentDeviceIdentifier = deviceIdentifier;
+            label = devices.GetDeviceByIdentifier(deviceIdentifier).FriendlyName + ": " + labl;
         }
 
         public bool IsDead()
@@ -71,14 +73,14 @@ namespace NK2Tray
             {
                 try
                 {
-                    deviceVolume.MasterVolumeLevelScalar = volume;
+                    devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.MasterVolumeLevelScalar = volume;                                   
                 }
                 catch (System.Runtime.InteropServices.InvalidComObjectException e)
                 {
                     // This catch handles the "COM object that has been separated from its underlying RCW cannot be used" issue.
                     // I believe this happens when we refresh the device when opening the menu, but this is fine for now.
                     Console.WriteLine($@"Error when setting master volume: {e.Message}");
-                    deviceVolume = parent.GetDeviceVolumeObject();
+                    AudioEndpointVolume deviceVolume = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume;
                     deviceVolume.MasterVolumeLevelScalar = volume;
                     Console.WriteLine($@"RETRY: Setting master volume to {volume}");
                 }
@@ -87,11 +89,15 @@ namespace NK2Tray
                     //TODO find out where this exception comes from and actually fix it
                     Console.WriteLine("COM Execption" + e);
                 }
+                catch (System.InvalidCastException e)
+                {                    
+                    Console.WriteLine("InvalidCastException Exeception" + e);
+                }
             } 
             else if (sessionType == SessionType.Focus)
             {
                 var pid = WindowTools.GetForegroundPID();
-                var mixerSession = parent.FindMixerSessions(pid);
+                var mixerSession = devices.FindMixerSessions(pid);
                 // Check if null since mixer session might not exist for currently focused window
                 if (mixerSession != null)
                 {
@@ -121,7 +127,7 @@ namespace NK2Tray
             {
                 try
                 {
-                    var curVol = deviceVolume.MasterVolumeLevelScalar;
+                    var curVol = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.MasterVolumeLevelScalar;
                     if (curVol < 0)
                         curVol = 0;
                     if (curVol > 1)
@@ -133,7 +139,7 @@ namespace NK2Tray
                     // This catch handles the "COM object that has been separated from its underlying RCW cannot be used" issue.
                     // I believe this happens when we refresh the device when opening the menu, but this is fine for now.
                     Console.WriteLine($@"Error when getting master volume: {e.Message}");
-                    var curVol = deviceVolume.MasterVolumeLevelScalar;
+                    var curVol = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.MasterVolumeLevelScalar;
                     if (curVol < 0)
                         curVol = 0;
                     if (curVol > 1)
@@ -144,7 +150,7 @@ namespace NK2Tray
             else if (sessionType == SessionType.Focus)
             {
                 var pid = WindowTools.GetForegroundPID();
-                var mixerSession = parent.FindMixerSessions(pid);
+                var mixerSession = devices.FindMixerSessions(pid);
                 if (mixerSession != null)
                 {
                     foreach (var session in mixerSession.audioSessions)
@@ -188,13 +194,13 @@ namespace NK2Tray
             {
                 try
                 {
-                    var curVol = deviceVolume.MasterVolumeLevelScalar;
+                    var curVol = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.MasterVolumeLevelScalar;
                     curVol += change;
                     if (curVol < 0)
                         curVol = 0;
                     if (curVol > 1)
                         curVol = 1;
-                    deviceVolume.MasterVolumeLevelScalar = curVol;
+                    devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.MasterVolumeLevelScalar = curVol;
                     retVol = curVol;
                 }
                 catch (System.Runtime.InteropServices.InvalidComObjectException e)
@@ -202,7 +208,7 @@ namespace NK2Tray
                     // This catch handles the "COM object that has been separated from its underlying RCW cannot be used" issue.
                     // I believe this happens when we refresh the device when opening the menu, but this is fine for now.
                     Console.WriteLine($@"Error when setting master volume: {e.Message}");
-                    deviceVolume = parent.GetDeviceVolumeObject();
+                    AudioEndpointVolume deviceVolume = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume;
                     var curVol = deviceVolume.MasterVolumeLevelScalar;
                     curVol += change;
                     if (curVol < 0)
@@ -217,7 +223,7 @@ namespace NK2Tray
             else if (sessionType == SessionType.Focus)
             {
                 var pid = WindowTools.GetForegroundPID();
-                var mixerSession = parent.FindMixerSessions(pid);
+                var mixerSession = devices.FindMixerSessions(pid);
                 if( mixerSession != null)
                 {
                     foreach (var session in mixerSession.audioSessions)
@@ -249,8 +255,8 @@ namespace NK2Tray
             {
                 try
                 {
-                    var muted = !deviceVolume.Mute;
-                    deviceVolume.Mute = muted;
+                    var muted = !devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.Mute;
+                    devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.Mute = muted;
                     return muted;
                 }
                 catch (System.Runtime.InteropServices.InvalidComObjectException e)
@@ -258,7 +264,7 @@ namespace NK2Tray
                     // This catch handles the "COM object that has been separated from its underlying RCW cannot be used" issue.
                     // I believe this happens when we refresh the device when opening the menu, but this is fine for now.
                     Console.WriteLine($@"Error when toggling mute on master volume: {e.Message}");
-                    deviceVolume = parent.GetDeviceVolumeObject();
+                    AudioEndpointVolume deviceVolume = devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume;
                     var muted = !deviceVolume.Mute;
                     deviceVolume.Mute = muted;
 
@@ -269,7 +275,7 @@ namespace NK2Tray
             else if (sessionType == SessionType.Focus)
             {
                 var pid = WindowTools.GetForegroundPID();
-                var mixerSession = parent.FindMixerSessions(pid);
+                var mixerSession = devices.FindMixerSessions(pid);
                 if (mixerSession != null)
                 {
                     var muted = !mixerSession.audioSessions.First().SimpleAudioVolume.Mute;

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -15,6 +15,21 @@
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -100,6 +115,18 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="nk2tray.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 e x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Fody.3.3.5\build\Fody.targets" Condition="Exists('..\packages\Fody.3.3.5\build\Fody.targets')" />

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -26,7 +26,7 @@ namespace NK2Tray
 
         public NanoKontrol2(AudioDevice audioDev)
         {
-            audioDevice = audioDev;
+            audioDevices = audioDev;
             FindMidiIn();
             FindMidiOut();
             if (Found)

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -62,7 +62,7 @@ namespace NK2Tray
 
         public XtouchMini(AudioDevice audioDev)
         {
-            audioDevice = audioDev;
+            audioDevices = audioDev;
             FindMidiIn();
             FindMidiOut();
             if (Found)


### PR DESCRIPTION
Added multiple devices support ( master lines );
Added support to re-routed applications ( with EarTrumpet, for example );
Better performance changing volumes ( cache usage );
Fixed fader losing the assigned app if the app isn't open during NK2Tray boot ( maybe I broke this one myself, can't say =/ );