### PR TITLE
disable input device control

### DIFF
--- a/NK2Tray/AudioDevice.cs
+++ b/NK2Tray/AudioDevice.cs
@@ -117,6 +117,8 @@ namespace NK2Tray
                 }
             }
 
+            /*
+            // Commented out Iput device code because it breaks the session lists when input and ouput is controlled at the same time
             for (int j = 0; j < inputDevices.Count; j++)
             {
                 var sessions = inputDevices[j].AudioSessionManager.Sessions;
@@ -132,17 +134,14 @@ namespace NK2Tray
                         sessionsByIdent[searchIdentifier].Add(session);
                     }
                 }
-
-
             }
+            */
 
             foreach (var ident in sessionsByIdent.Keys.ToList())
             {
                 var identSessions = sessionsByIdent[ident]; //.OrderBy(i => (int)Process.GetProcessById((int)i.GetProcessID).MainWindowHandle).ToList();
 
                 bool dup = identSessions.Count > 1;
-                
-                SessionType sessionType = SessionType.Application;
 
                 var process = FindLivingProcess(identSessions);
                 string label = (process != null) ? process.ProcessName : ident;
@@ -150,7 +149,7 @@ namespace NK2Tray
                 if (HasSystemSoundsSession(identSessions))
                     label = "System Sounds";
                                 
-                var mixerSession = new MixerSession(this, label, ident, identSessions, sessionType);
+                var mixerSession = new MixerSession(this, label, ident, identSessions, SessionType.Application);
                 mixerSessions.Add(mixerSession);
             }
 

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -97,11 +97,14 @@ namespace NK2Tray
                 masterMixerSessionList.Add(new MixerSession(mmDevice.ID, audioDevices, "Master", SessionType.Master));
             }
 
+            /*
+            // Commented out Iput device code because it breaks the session lists when input and ouput is controlled at the same time
             var micMixerSessionList = new List<MixerSession>();
             foreach (MMDevice mmDevice in audioDevices.inputDevices)
             {
                 micMixerSessionList.Add(new MixerSession(mmDevice.ID, audioDevices, "Microphone", SessionType.Master));
             }
+            */
 
             MixerSession focusMixerSession;
             focusMixerSession = new MixerSession("", audioDevices, "Focus", SessionType.Focus);
@@ -129,6 +132,8 @@ namespace NK2Tray
                     faderMenu.MenuItems.Add(masterItem);
                 }
 
+                /* 
+                // Commented out Iput device code because it breaks the session lists when input and ouput is controlled at the same time
                 faderMenu.MenuItems.Add("-");
 
                 foreach (MixerSession mixerSession in micMixerSessionList)
@@ -137,6 +142,7 @@ namespace NK2Tray
                     micItem.Tag = new object[] { fader, mixerSession };
                     faderMenu.MenuItems.Add(micItem);
                 }
+                */
 
                 faderMenu.MenuItems.Add("-");
 


### PR DESCRIPTION
temporarily disable control of input devices as it breaks control of applications that use both input and output devices.