### PR TITLE
corrected handling if fader identifier is empty... so no crash happens

### DIFF
--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -72,8 +72,8 @@ namespace NK2Tray
         {
             if (fader.assigned)
                 return fader.assignment.label;
-
-            if(fader.identifier.Length > 0 && fader.identifier.Contains(".exe"))
+            
+            if(fader.identifier != null && fader.identifier.Length > 0 && fader.identifier.Contains(".exe"))
             {
                 String identifier = fader.identifier;
                 int lastBackSlash = identifier.LastIndexOf('\\') + 1;


### PR DESCRIPTION
corrected handling if fader is empty so it is working again also without config file. preparations for hotfix without mic control