### PR TITLE
📈 Logarithmic volume curve

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -96,6 +96,7 @@ namespace NK2Tray
         {
             pow = _pow;
             steps = calculateSteps();
+            parent.SetVolumeIndicator(faderNumber, assignment != null ? assignment.GetVolume() : -1);
         }
 
         private float[] calculateSteps()
@@ -291,10 +292,9 @@ namespace NK2Tray
                             nextStepIndex = Math.Min(nearestStep + 1, steps.Length - 1);
 
                         var newVol = steps[nextStepIndex];
-                        var newVolIndicator = (float)nextStepIndex / (float)(steps.Length - 1);
 
                         assignment.SetVolume(newVol);
-                        parent.SetVolumeIndicator(faderNumber, newVolIndicator);
+                        parent.SetVolumeIndicator(faderNumber, newVol);
                     }
                     else
                     {

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -80,8 +80,7 @@ namespace NK2Tray
             midiOut = midiDevice.midiOut;
             faderNumber = faderNum;
             faderDef = parent.DefaultFaderDef;
-            pow = 1f;
-            steps = calculateSteps();
+            SetCurve(1f);
         }
 
         public Fader(MidiDevice midiDevice, int faderNum, FaderDef _faderDef)
@@ -90,18 +89,7 @@ namespace NK2Tray
             midiOut = midiDevice.midiOut;
             faderNumber = faderNum;
             faderDef = _faderDef;
-            pow = 1f;
-            steps = calculateSteps();
-        }
-
-        public Fader(MidiDevice midiDevice, int faderNum, FaderDef _faderDef, float _pow)
-        {
-            parent = midiDevice;
-            midiOut = midiDevice.midiOut;
-            faderNumber = faderNum;
-            faderDef = _faderDef;
-            pow = _pow;
-            steps = calculateSteps();
+            SetCurve(1f);
         }
 
         public void SetCurve(float _pow)

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
 
 namespace NK2Tray
 {
@@ -293,22 +292,9 @@ namespace NK2Tray
                         var volumeGoingDown = val > faderDef.range / 2;
 
                         if (volumeGoingDown)
-                        {
                             nextStepIndex = Math.Max(nearestStep - 1, 0);
-                        }
                         else
-                        {
                             nextStepIndex = Math.Min(nearestStep + 1, steps.Length - 1);
-                        }
-
-                        /*
-                        if (val > faderDef.range / 2)
-                            // Volume down
-                            curVol = assignment.ChangeVolume((faderDef.range - val) / faderDef.range);
-                        else
-                            // Volume up
-                            curVol = assignment.ChangeVolume(val / faderDef.range);
-                        */
 
                         var newVol = steps[nextStepIndex];
                         var newVolIndicator = (float)nextStepIndex / (float)(steps.Length - 1);
@@ -318,7 +304,6 @@ namespace NK2Tray
                     }
                     else
                     {
-                        // assignment.SetVolume(GetValue(e.MidiEvent) / faderDef.range);
                         assignment.SetVolume(getVolFromStage(GetValue(e.MidiEvent)));
                     }
 

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -147,9 +147,9 @@ namespace NK2Tray
             buttons = new List<Button>();
         }
 
-        public virtual void SetCurve(float pow)
+        public void SetCurve(float pow)
         {
-            DefaultFaderDef.SetCurve(pow);
+            faders.ForEach(fader => fader.SetCurve(pow));
         }
 
         public void LoadAssignments()

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -147,6 +147,10 @@ namespace NK2Tray
             buttons = new List<Button>();
         }
 
+        public virtual void SetCurve(float pow)
+        {
+            DefaultFaderDef.SetCurve(pow);
+        }
 
         public void LoadAssignments()
         {

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -41,11 +41,6 @@ namespace NK2Tray
             }
         }
 
-        public override void SetCurve(float pow)
-        {
-            DefaultFaderDef.SetCurve(pow);
-        }
-
         public override void ResetAllLights()
         {
             foreach (var i in Enumerable.Range(0, 128))

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -41,6 +41,11 @@ namespace NK2Tray
             }
         }
 
+        public override void SetCurve(float pow)
+        {
+            DefaultFaderDef.SetCurve(pow);
+        }
+
         public override void ResetAllLights()
         {
             foreach (var i in Enumerable.Range(0, 128))

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -16,6 +16,7 @@ namespace NK2Tray
         private NotifyIcon trayIcon;
         public MidiDevice midiDevice;
         public AudioDevice audioDevices;
+        public bool logarithmic;
 
         public SysTrayApp()
         {
@@ -29,10 +30,12 @@ namespace NK2Tray
                 ContextMenu = new ContextMenu()
             };
             trayIcon.ContextMenu.Popup += OnPopup;
-
             trayIcon.Visible = true;
 
             SetupDevice();
+
+            logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
+            midiDevice.SetCurve(logarithmic ? 3f : 1f);
         }
 
         private Boolean SetupDevice()
@@ -169,7 +172,21 @@ namespace NK2Tray
                 faderMenu.MenuItems.Add(unassignItem);                
             }
 
+            trayMenu.MenuItems.Add("-");
+
+            MenuItem logCheck = new MenuItem("Logarithmic");
+            logCheck.Checked = logarithmic;
+            trayMenu.MenuItems.Add(logCheck);
+
+            trayMenu.MenuItems.Add("-");
             trayMenu.MenuItems.Add("Exit", OnExit);
+        }
+
+        private void ToggleLogarithmic(object sender, EventArgs e)
+        {
+            logarithmic = !logarithmic;
+            ConfigSaver.AddOrUpdateAppSettings("logarithmic", System.Convert.ToString(logarithmic));
+            midiDevice.SetCurve(logarithmic ? 3f : 1f);
         }
 
         private void AssignFader(object sender, EventArgs e)

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -174,7 +174,7 @@ namespace NK2Tray
 
             trayMenu.MenuItems.Add("-");
 
-            MenuItem logCheck = new MenuItem("Logarithmic");
+            MenuItem logCheck = new MenuItem("Logarithmic", ToggleLogarithmic);
             logCheck.Checked = logarithmic;
             trayMenu.MenuItems.Add(logCheck);
 

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -30,12 +30,13 @@ namespace NK2Tray
                 ContextMenu = new ContextMenu()
             };
             trayIcon.ContextMenu.Popup += OnPopup;
+
             trayIcon.Visible = true;
 
             SetupDevice();
 
             logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
-            midiDevice.SetCurve(logarithmic ? 3f : 1f);
+            SaveLogarithmic();
         }
 
         private Boolean SetupDevice()
@@ -174,6 +175,7 @@ namespace NK2Tray
 
             trayMenu.MenuItems.Add("-");
 
+            // Add toggle option for logarithmic volume curve
             MenuItem logCheck = new MenuItem("Logarithmic", ToggleLogarithmic);
             logCheck.Checked = logarithmic;
             trayMenu.MenuItems.Add(logCheck);
@@ -186,7 +188,12 @@ namespace NK2Tray
         {
             logarithmic = !logarithmic;
             ConfigSaver.AddOrUpdateAppSettings("logarithmic", System.Convert.ToString(logarithmic));
-            midiDevice.SetCurve(logarithmic ? 3f : 1f);
+            SaveLogarithmic();
+        }
+
+        private void SaveLogarithmic()
+        {
+            midiDevice.SetCurve(logarithmic ? 1.5f : 1f);
         }
 
         private void AssignFader(object sender, EventArgs e)

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -193,7 +193,7 @@ namespace NK2Tray
 
         private void SaveLogarithmic()
         {
-            midiDevice.SetCurve(logarithmic ? 1.5f : 1f);
+            midiDevice.SetCurve(logarithmic ? 2f : 1f);
         }
 
         private void AssignFader(object sender, EventArgs e)

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -76,16 +76,26 @@ namespace NK2Tray
             }
         }
 
-        public override void SetVolumeIndicator(int fader, float level)
+        public override void SetVolumeIndicator(int faderNum, float level)
         {
             if (level >= 0)
             {
-                var val = (int)Math.Round(level * 12) + 1 + 16 * 2;
-                Console.WriteLine($@"Setting fader {fader} display to {level} ({val})");
-                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(fader + 48), val).GetAsShortMessage());
+                var usedLevel = level;
+                var fader = faders[faderNum];
+
+                if (fader.faderDef.delta)
+                {
+                    var nearestStep = fader.steps.Select((x, i) => new { Index = i, Distance = Math.Abs(level - x) }).OrderBy(x => x.Distance).First().Index;
+                    usedLevel = (float)nearestStep / (fader.steps.Length - 1);
+                }
+
+                var val = (int)Math.Round(usedLevel * 12) + 1 + 16 * 2;
+
+                Console.WriteLine($@"Setting fader {fader} display to {usedLevel} ({val})");
+                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(faderNum + 48), val).GetAsShortMessage());
             }
             else
-                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(fader + 48), 0).GetAsShortMessage());
+                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(faderNum + 48), 0).GetAsShortMessage());
         }
 
         public override void ResetAllLights()

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -76,6 +76,13 @@ namespace NK2Tray
             }
         }
 
+        public override void SetCurve(float pow)
+        {
+            DefaultFaderDef.SetCurve(pow);
+            FirstTwoFaderDef.SetCurve(pow);
+            MasterFaderDef.SetCurve(pow);
+        }
+
         public override void SetVolumeIndicator(int fader, float level)
         {
             if (level >= 0)

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -76,13 +76,6 @@ namespace NK2Tray
             }
         }
 
-        public override void SetCurve(float pow)
-        {
-            DefaultFaderDef.SetCurve(pow);
-            FirstTwoFaderDef.SetCurve(pow);
-            MasterFaderDef.SetCurve(pow);
-        }
-
         public override void SetVolumeIndicator(int fader, float level)
         {
             if (level >= 0)


### PR DESCRIPTION
Hi there!

This PR adds a "_Logarithmic_" option to the popup menu that controls whether the volume slider is linear or logarithmic. This utility is a God-send, but Windows' volume mixer being linear means I have the majority of my inputs at very low settings most of the time.

It uses a [_not-so-ideal-but-still-quite-good curve_](https://www.dr-lex.be/info-stuff/volumecontrols.html).

Notable changes:

- Each `Fader` now has its own `power` setting. Currently, the _Logarithmic_ option sets this to `2f`. Otherwise, it's `1f`.
- Upon setup or changing the _Logarithmic_ option, `Fader`s that are actually knobs (or otherwise use a MIDI "note" to go up/down) set up an array of "steps", listing each volume level they should hit at each interval. When a volume is set, it firsts find what interval it's at before moving to the next/previous one. This solves some volume jumping that happened when changing volumes without NK2.

Please shout if you need any specific changes for this (or whether it's something that's seen as useful). I'm not a C# dev by trade, so pieces here might be a bit shaky. 😉