### PR TITLE
Fix X-Touch Mini slider only moving volume to 99

### DIFF
--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -45,7 +45,7 @@ namespace NK2Tray
 
         public FaderDef MasterFaderDef => new FaderDef(
             false,  // delta
-            16383f, // range
+            16256f, // range
             1,      // channel
             true,   // selectPresent
             true,   // mutePresent


### PR DESCRIPTION
PR to fix #47.

`GetValue(e.MidiEvent)` gave me a maximum value of `16256f` as opposed to the `16383f` listed in the setup, so this should fix it up!

