### PR TITLE
handle odd "System Sounds" identifier of "#" when trying to set app path

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -134,7 +134,13 @@ namespace NK2Tray
 
         private void convertToApplicationPath(string ident)
         {
-            if (ident != null && ident != "" && !ident.Substring(0, Math.Min(10, ident.Length)).Equals("__MASTER__") && ident != "__FOCUS__") // TODO cleaner handling of special fader types
+            if (
+                ident != null
+                && ident != ""
+                && !ident.StartsWith("#")
+                && !ident.Substring(0, Math.Min(10, ident.Length)).Equals("__MASTER__")
+                && ident != "__FOCUS__"
+            ) // TODO cleaner handling of special fader types
             {
                 //"{0.0.0.00000000}.{...}|\\Device\\HarddiskVolume8\\Users\\Dr. Locke\\AppData\\Roaming\\Spotify\\Spotify.exe%b{00000000-0000-0000-0000-000000000000}"
                 int deviceIndex = ident.IndexOf("\\Device");
@@ -308,7 +314,11 @@ namespace NK2Tray
                 }
 
                 // Record match
-                if (assigned && Match(faderNumber, e.MidiEvent, faderDef.recordCode, faderDef.recordOffset, faderDef.recordChannelOverride))
+                if (
+                    assigned
+                    && applicationPath != null
+                    && Match(faderNumber, e.MidiEvent, faderDef.recordCode, faderDef.recordOffset, faderDef.recordChannelOverride)
+                )
                 {
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;


### PR DESCRIPTION
PR to fix #48.

The "_System Sounds_" mixer session returns a weird identifier in the form of...
```
#%b{00000000-0000-0000-0000-000000000000}
```
...instead of one with an executable path as expected like...
```
{0.0.0.00000000}.{...}|\\Device\\HarddiskVolume8\\Users\\Dr. Locke\\AppData\\Roaming\\Spotify\\Spotify.exe%b{00000000-0000-0000-0000-000000000000}
```

This PR should help handle that case instead of freaking out trying to retrieve a path for the executable.

It's worth mentioning that #48 mentions that this bug occurs whenever the program _restarts_. For me, this happens as soon as I assign _System Sounds_ to a fader, which crashes the program.

Might be worth checking that the ID above matches what other folks are getting.