### PR TITLE
🎹 Add a basic OP-1 profile

### DIFF
--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -86,6 +86,7 @@
     <Compile Include="NanoKontrol2.cs" />
     <Compile Include="MidiDevice.cs" />
     <Compile Include="MixerSession.cs" />
+    <Compile Include="OP1.cs" />
     <Compile Include="Program.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/NK2Tray/OP1.cs
+++ b/NK2Tray/OP1.cs
@@ -1,0 +1,125 @@
+using NAudio.Midi;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NK2Tray
+{
+    public class OP1 : MidiDevice
+    {
+        public override string SearchString => "op-1";
+
+        public FaderDef FirstFader => new FaderDef(
+            false,   // delta
+            127f,    // range
+            1,      // channel
+            true,   // selectPresent
+            true,   // mutePresent
+            true,  // recordPresent
+            1,      // faderOffset
+            64,     // selectOffset
+            50,     // muteOffset
+            51,     // recordOffset
+            MidiCommandCode.ControlChange,  // faderCode
+            MidiCommandCode.ControlChange,  // selectCode
+            MidiCommandCode.ControlChange,  // muteCode
+            MidiCommandCode.ControlChange   // recordCode
+        );
+
+        public FaderDef SecondFader => new FaderDef(
+            false,   // delta
+            127f,    // range
+            1,      // channel
+            true,   // selectPresent
+            true,   // mutePresent
+            true,  // recordPresent
+            1,      // faderOffset
+            64,     // selectOffset
+            51,     // muteOffset
+            20,     // recordOffset
+            MidiCommandCode.ControlChange,  // faderCode
+            MidiCommandCode.ControlChange,  // selectCode
+            MidiCommandCode.ControlChange,  // muteCode
+            MidiCommandCode.ControlChange   // recordCode
+        );
+
+        public FaderDef ThirdFader => new FaderDef(
+            false,   // delta
+            127f,    // range
+            1,      // channel
+            true,   // selectPresent
+            true,   // mutePresent
+            true,  // recordPresent
+            1,      // faderOffset
+            64,     // selectOffset
+            20,     // muteOffset
+            21,     // recordOffset
+            MidiCommandCode.ControlChange,  // faderCode
+            MidiCommandCode.ControlChange,  // selectCode
+            MidiCommandCode.ControlChange,  // muteCode
+            MidiCommandCode.ControlChange   // recordCode
+        );
+
+        public FaderDef FourthFader => new FaderDef(
+            false,   // delta
+            127f,    // range
+            1,      // channel
+            true,   // selectPresent
+            true,   // mutePresent
+            true,  // recordPresent
+            1,      // faderOffset
+            64,     // selectOffset
+            21,     // muteOffset
+            22,     // recordOffset
+            MidiCommandCode.ControlChange,  // faderCode
+            MidiCommandCode.ControlChange,  // selectCode
+            MidiCommandCode.ControlChange,  // muteCode
+            MidiCommandCode.ControlChange   // recordCode
+        );
+
+        public OP1(AudioDevice audioDev)
+        {
+            audioDevices = audioDev;
+            FindMidiIn();
+            FindMidiOut();
+
+            if (Found)
+            {
+                InitFaders();
+                InitButtons();
+                LoadAssignments();
+                ListenForMidi();
+            }
+        }
+
+        public override void InitFaders()
+        {
+            faders = new List<Fader>
+            {
+                new Fader(this, 0, FirstFader),
+                new Fader(this, 1, SecondFader),
+                new Fader(this, 2, ThirdFader),
+                new Fader(this, 3, FourthFader)
+            };
+        }
+
+        public override void InitButtons()
+        {
+            buttons = new List<Button>
+            {
+                new Button(ref midiOut, ButtonType.MediaPlay, 39, true),
+                new Button(ref midiOut, ButtonType.MediaStop, 40, false),
+                new Button(ref midiOut, ButtonType.MediaNext, 16, true),
+                new Button(ref midiOut, ButtonType.MediaPrevious, 15, true)
+            };
+
+            // is this still needed?
+            buttonsMappingTable = new Hashtable();
+
+            foreach (var button in buttons)
+            {
+                buttonsMappingTable.Add(button.controller, button);
+            }
+        }
+    }
+}

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -56,8 +56,12 @@ namespace NK2Tray
             audioDevices = new AudioDevice();
 
             midiDevice = new NanoKontrol2(audioDevices);
+
             if (!midiDevice.Found)
                 midiDevice = new XtouchMini(audioDevices);
+
+            if (!midiDevice.Found)
+                midiDevice = new OP1(audioDevices);
 
             audioDevices.midiDevice = midiDevice;
 


### PR DESCRIPTION
Adds a profile for Teenage Engineering OP-1 Portable Synthesizer.

![image](https://user-images.githubusercontent.com/1736957/81301735-57fb1b80-9071-11ea-99ef-53dfa692c7c5.png)

The OP-1 isn't really made to be used solely as a MIDI controller, so there's not much feedback that can be given in the form of lights. That said, it can still provide the functionality needed to do what this utility does best!

**Utilised hardware:**

- Play button in the bottom left for "Play/Pause"
- Stop button in the bottom left for "Stop"
- Button above play button for "Next"
- Button above the record button for "Previous"
- Each coloured fader works:
    - Moving the fader across a range of `0f` to `127f`
    - Clicking the fader assigns the focused application to that fader
    - The bottom-left button (i.e. 1/3/5/7) mutes the assigned application
    - The bottom-right button (i.e. 2/4/6/8) boots the assigned application if it's not running

Some caveats/notable points:

- The two more obvious buttons to be used for "Next" and "Previous" media controls provide no MIDI output and are instead used to transpose the keyboard up and down octaves. Thus, they can't be used.
- The main volume control looks like it's hardware-only; there's no MIDI output from this, so we can't use it here.
- The four coloured rotary encoders, while they appear infinite, actually output a distinct value from `0` to `127` just like a slider. For now, that means they're treated as a slider, even though it's impossible to know what value they're at before you move one. There could be some small edits we could make to `Fader.cs` to create a sort of "semi-delta" mode to iron out this issue in the future.

---

Again, let me know if anything needs any changes here or if there's anything that can be done more elegantly. I found it really easy to set this up using the current examples for the NK2 and XTM and the amount of code is really minimal. That's awesome!