### PR TITLE
🔇 Set mute light on (un)assignment

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -121,6 +121,7 @@ namespace NK2Tray
             assigned = false;
             SetSelectLight(true);
             SetRecordLight(true);
+            SetMuteLight(false);
         }
 
         public void Unassign()
@@ -129,6 +130,7 @@ namespace NK2Tray
             assignment = null;
             SetSelectLight(false);
             SetRecordLight(false);
+            SetMuteLight(false);
             identifier = "";
             if (faderDef.delta)
                 parent.SetVolumeIndicator(faderNumber, -1);

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -108,6 +108,8 @@ namespace NK2Tray
             applicationName = mixerSession.label;
             SetSelectLight(true);
             SetRecordLight(false);
+            SetMuteLight(mixerSession.GetMute());
+
             if (faderDef.delta)
                 parent.SetVolumeIndicator(faderNumber, mixerSession.GetVolume());
         }

--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -290,5 +290,23 @@ namespace NK2Tray
             }
             return false;
         }
+
+        public bool GetMute()
+        {
+            if (sessionType == SessionType.Master)
+                return devices.GetDeviceByIdentifier(parentDeviceIdentifier).AudioEndpointVolume.Mute;
+
+            var targetAudioSessions = audioSessions;
+
+            if (sessionType == SessionType.Focus)
+            {
+                var pid = WindowTools.GetForegroundPID();
+                var mixerSession = devices.FindMixerSession(pid);
+                if (mixerSession == null) return false;
+                targetAudioSessions = mixerSession.audioSessions;
+            }
+
+            return targetAudioSessions.First().SimpleAudioVolume.Mute;
+        }
     }
 }


### PR DESCRIPTION
Currently, assigning a fader to something doesn't take in to account its muted status. This means, for example, you can assign a fader to a muted application but the controller won't reflect its muted status until you unmute and mute it again.

This PR should fix that by grabbing the muted status on assignment and removing it on unassignment.