### PR TITLE
Menu to select the active MIDI device

### DIFF
--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -26,6 +26,9 @@ namespace NK2Tray
     {
         public MidiIn midiIn;
         public MidiOut midiOut;
+        public bool midiInDetected;
+        public bool midiOutDetected;
+        public string name;
 
         public List<Fader> faders;
         public List<Button> buttons;
@@ -42,7 +45,6 @@ namespace NK2Tray
             Console.WriteLine($@"Initializing Midi Device {SearchString}");
         }
 
-        public bool Found => (midiIn != null && midiOut != null);
         public virtual void Setup(bool takeControl = true)
         {
             FindMidiIn(takeControl);
@@ -59,28 +61,40 @@ namespace NK2Tray
             }
         }
 
-        public void FindMidiIn()
+        public bool Found => ((midiInDetected && midiOutDetected) || (midiIn != null && midiOut != null));
+
+        public void FindMidiIn(bool takeControl = true)
         {
             for (int i = 0; i < MidiIn.NumberOfDevices; i++)
             {
                 Console.WriteLine("MIDI IN: " + MidiIn.DeviceInfo(i).ProductName);
                 if (MidiIn.DeviceInfo(i).ProductName.ToLower().Contains(SearchString))
                 {
-                    midiIn = new MidiIn(i);
+                    name = MidiIn.DeviceInfo(i).ProductName;
+
+                    if (takeControl)
+                        midiIn = new MidiIn(i);
+                    else
+                        midiInDetected = true;
+
                     Console.WriteLine($@"Assigning MidiIn: {MidiIn.DeviceInfo(i).ProductName}");
                     break;
                 }
             }
         }
 
-        public void FindMidiOut()
+        public void FindMidiOut(bool takeControl = true)
         {
             for (int i = 0; i < MidiOut.NumberOfDevices; i++)
             {
                 Console.WriteLine("MIDI OUT: " + MidiOut.DeviceInfo(i).ProductName);
                 if (MidiOut.DeviceInfo(i).ProductName.ToLower().Contains(SearchString))
                 {
-                    midiOut = new MidiOut(i);
+                    if (takeControl)
+                        midiOut = new MidiOut(i);
+                    else
+                        midiOutDetected = true;
+
                     Console.WriteLine($@"Assigning MidiOut: {MidiOut.DeviceInfo(i).ProductName}");
                     break;
                 }

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -222,5 +222,11 @@ namespace NK2Tray
             }
         }
 
+        public void Close()
+        {
+            ResetAllLights();
+            if (midiIn != null) midiIn.Dispose();
+            if (midiOut != null) midiOut.Dispose();
+        }
     }
 }

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -43,6 +43,21 @@ namespace NK2Tray
         }
 
         public bool Found => (midiIn != null && midiOut != null);
+        public virtual void Setup(bool takeControl = true)
+        {
+            FindMidiIn(takeControl);
+            FindMidiOut(takeControl);
+
+            if (Found && takeControl)
+            {
+                ResetAllLights();
+                InitFaders();
+                InitButtons();
+                LightShow();
+                LoadAssignments();
+                ListenForMidi();
+            }
+        }
 
         public void FindMidiIn()
         {

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -25,20 +25,10 @@ namespace NK2Tray
             MidiCommandCode.ControlChange // recordCode
         );
 
-        public NanoKontrol2(AudioDevice audioDev)
+        public NanoKontrol2(AudioDevice audioDev, bool takeControl = true)
         {
             audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LightShow();
-                LoadAssignments();
-                ListenForMidi();
-            }
+            Setup(takeControl);
         }
 
         public override void ResetAllLights()

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -79,24 +79,22 @@ namespace NK2Tray
             if (midiDevice == null)
                 midiDevice = PickNewDevice(midiDevices.First().name);
 
-            logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
-            SaveLogarithmic();
-
             return midiDevice.Found;
         }
 
         private MidiDevice PickNewDevice(string name)
         {
-            var newMidiDevice = midiDevices.Find(device => device.name == name);
-            if (newMidiDevice == null) return null;
+            if (midiDevice != null) midiDevice.Close();
+            midiDevice = midiDevices.Find(device => device.name == name);
 
-            newMidiDevice.Setup();
+            if (midiDevice != null)
+            {
+                midiDevice.Setup();
+                ConfigSaver.AddOrUpdateAppSettings("midi-device", midiDevice.name);
 
-            var oldMidiDevice = midiDevice;
-            midiDevice = newMidiDevice;
-            if (oldMidiDevice != null) oldMidiDevice.Close();
-
-            ConfigSaver.AddOrUpdateAppSettings("midi-device", midiDevice.name);
+                logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
+                SaveLogarithmic();
+            }
 
             return midiDevice;
         }

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -61,19 +61,10 @@ namespace NK2Tray
             9      // faderChannelOverride
         );
 
-        public XtouchMini(AudioDevice audioDev)
+        public XtouchMini(AudioDevice audioDev, bool takeControl = true)
         {
             audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LoadAssignments();
-                ListenForMidi();
-            }
+            Setup(takeControl);
         }
 
         public override void SetVolumeIndicator(int faderNum, float level)


### PR DESCRIPTION
This adds a menu to the pop-up that allows the user to select which MIDI device is currently being used to control NK2Tray.

![image](https://user-images.githubusercontent.com/1736957/81321248-4114f300-908a-11ea-9d80-5a93a5e62e02.png)

When one device is selected over another, the previous device is released so other programs can take control of it. In addition, the last-used device should be saved using the handy `ConfigSaver`, so NK2Tray will try to use that device again when it starts.

I'm not in possession of an NK2 controller so can't test 3 controllers together, but two seems to be working fine.