### PR TITLE
Detection of MIDI devices connecting/disconnecting

### DIFF
--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -26,6 +26,9 @@ namespace NK2Tray
     {
         public MidiIn midiIn;
         public MidiOut midiOut;
+        public bool midiInDetected;
+        public bool midiOutDetected;
+        public string name;
 
         public List<Fader> faders;
         public List<Button> buttons;
@@ -42,7 +45,6 @@ namespace NK2Tray
             Console.WriteLine($@"Initializing Midi Device {SearchString}");
         }
 
-        public bool Found => (midiIn != null && midiOut != null);
         public virtual void Setup(bool takeControl = true)
         {
             FindMidiIn(takeControl);
@@ -59,28 +61,40 @@ namespace NK2Tray
             }
         }
 
-        public void FindMidiIn()
+        public bool Found => ((midiInDetected && midiOutDetected) || (midiIn != null && midiOut != null));
+
+        public void FindMidiIn(bool takeControl = true)
         {
             for (int i = 0; i < MidiIn.NumberOfDevices; i++)
             {
                 Console.WriteLine("MIDI IN: " + MidiIn.DeviceInfo(i).ProductName);
                 if (MidiIn.DeviceInfo(i).ProductName.ToLower().Contains(SearchString))
                 {
-                    midiIn = new MidiIn(i);
+                    name = MidiIn.DeviceInfo(i).ProductName;
+
+                    if (takeControl)
+                        midiIn = new MidiIn(i);
+                    else
+                        midiInDetected = true;
+
                     Console.WriteLine($@"Assigning MidiIn: {MidiIn.DeviceInfo(i).ProductName}");
                     break;
                 }
             }
         }
 
-        public void FindMidiOut()
+        public void FindMidiOut(bool takeControl = true)
         {
             for (int i = 0; i < MidiOut.NumberOfDevices; i++)
             {
                 Console.WriteLine("MIDI OUT: " + MidiOut.DeviceInfo(i).ProductName);
                 if (MidiOut.DeviceInfo(i).ProductName.ToLower().Contains(SearchString))
                 {
-                    midiOut = new MidiOut(i);
+                    if (takeControl)
+                        midiOut = new MidiOut(i);
+                    else
+                        midiOutDetected = true;
+
                     Console.WriteLine($@"Assigning MidiOut: {MidiOut.DeviceInfo(i).ProductName}");
                     break;
                 }

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -222,5 +222,11 @@ namespace NK2Tray
             }
         }
 
+        public void Close()
+        {
+            ResetAllLights();
+            if (midiIn != null) midiIn.Dispose();
+            if (midiOut != null) midiOut.Dispose();
+        }
     }
 }

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -43,6 +43,21 @@ namespace NK2Tray
         }
 
         public bool Found => (midiIn != null && midiOut != null);
+        public virtual void Setup(bool takeControl = true)
+        {
+            FindMidiIn(takeControl);
+            FindMidiOut(takeControl);
+
+            if (Found && takeControl)
+            {
+                ResetAllLights();
+                InitFaders();
+                InitButtons();
+                LightShow();
+                LoadAssignments();
+                ListenForMidi();
+            }
+        }
 
         public void FindMidiIn()
         {

--- a/NK2Tray/MidiDeviceWatcher.cs
+++ b/NK2Tray/MidiDeviceWatcher.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Windows.Devices.Enumeration;
+
+namespace NK2Tray
+{
+    class MidiDeviceWatcher
+    {
+        private DeviceWatcher deviceWatcher;
+        private string deviceSelectorString;
+        private Func<bool> UpdateDevices;
+        private bool firstEnumerationComplete;
+
+        public DeviceInformationCollection DeviceInformationCollection { get; set; }
+
+        public MidiDeviceWatcher(string midiDeviceSelectorString, Func<bool> _updateDevices)
+        {
+            deviceSelectorString = midiDeviceSelectorString;
+            UpdateDevices = _updateDevices;
+
+            deviceWatcher = DeviceInformation.CreateWatcher(deviceSelectorString);
+            deviceWatcher.Added += DeviceWatcher_Added;
+            deviceWatcher.Removed += DeviceWatcher_Removed;
+            deviceWatcher.Updated += DeviceWatcher_Updated;
+            deviceWatcher.EnumerationCompleted += DeviceWatcher_EnumerationCompleted;
+        }
+
+        ~MidiDeviceWatcher()
+        {
+            deviceWatcher.Added -= DeviceWatcher_Added;
+            deviceWatcher.Removed -= DeviceWatcher_Removed;
+            deviceWatcher.Updated -= DeviceWatcher_Updated;
+            deviceWatcher.EnumerationCompleted -= DeviceWatcher_EnumerationCompleted;
+            deviceWatcher = null;
+        }
+
+        public void StartWatcher()
+        {
+            deviceWatcher.Start();
+        }
+
+        public void StopWatcher()
+        {
+            deviceWatcher.Stop();
+        }
+
+        private void DeviceWatcher_Added(DeviceWatcher sender, DeviceInformation args)
+        {
+            if (firstEnumerationComplete) UpdateDevices();
+        }
+
+        private void DeviceWatcher_Removed(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            if (firstEnumerationComplete) UpdateDevices();
+        }
+
+        private void DeviceWatcher_Updated(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            if (firstEnumerationComplete) UpdateDevices();
+        }
+
+        private void DeviceWatcher_EnumerationCompleted(DeviceWatcher sender, object args)
+        {
+            firstEnumerationComplete = true;
+            UpdateDevices();
+        }
+    }
+}

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -124,25 +123,16 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.3.3.5\build\Fody.targets" Condition="Exists('..\packages\Fody.3.3.5\build\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.3.3.5\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.3.3.5\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props'))" />
-  </Target>
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="3.3.0" />
-    <PackageReference Include="Fody">
-      <Version>3.3.5</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Costura.Fody">
+      <Version>3.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
       <Version>10.0.18362.2005</Version>
     </PackageReference>
-    <PackageReference Include="NAudio" Version="1.8.5" />
+    <PackageReference Include="NAudio">
+      <Version>1.8.5</Version>
+    </PackageReference>
   </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -142,9 +142,10 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="Costura.Fody" Version="3.3.0" />
-    <PackageReference Include="Fody" Version="3.3.35">
+    <PackageReference Include="Fody">
+      <Version>3.3.5</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NAudio" Version="1.8.5" />
   </ItemGroup>

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Fader.cs" />
     <Compile Include="IconExtractor.cs" />
     <Compile Include="MediaTools.cs" />
+    <Compile Include="MidiDeviceWatcher.cs" />
     <Compile Include="NanoKontrol2.cs" />
     <Compile Include="MidiDevice.cs" />
     <Compile Include="MixerSession.cs" />

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -147,6 +147,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts">
+      <Version>10.0.18362.2005</Version>
+    </PackageReference>
     <PackageReference Include="NAudio" Version="1.8.5" />
   </ItemGroup>
 </Project>

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -54,13 +54,6 @@
     <ApplicationIcon>nk2tray.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=3.3.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Costura.Fody.3.3.0\lib\net40\Costura.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NAudio, Version=1.8.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.8.5\lib\net35\NAudio.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -103,7 +96,6 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -140,4 +140,12 @@
     <Error Condition="!Exists('..\packages\Fody.3.3.5\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.3.3.5\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.3.3.0\build\Costura.Fody.props'))" />
   </Target>
+  <ItemGroup>
+    <PackageReference Include="Costura.Fody" Version="3.3.0" />
+    <PackageReference Include="Fody" Version="3.3.35">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NAudio" Version="1.8.5" />
+  </ItemGroup>
 </Project>

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -25,20 +25,10 @@ namespace NK2Tray
             MidiCommandCode.ControlChange // recordCode
         );
 
-        public NanoKontrol2(AudioDevice audioDev)
+        public NanoKontrol2(AudioDevice audioDev, bool takeControl = true)
         {
             audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LightShow();
-                LoadAssignments();
-                ListenForMidi();
-            }
+            Setup(takeControl);
         }
 
         public override void ResetAllLights()

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -61,19 +61,10 @@ namespace NK2Tray
             9      // faderChannelOverride
         );
 
-        public XtouchMini(AudioDevice audioDev)
+        public XtouchMini(AudioDevice audioDev, bool takeControl = true)
         {
             audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LoadAssignments();
-                ListenForMidi();
-            }
+            Setup(takeControl);
         }
 
         public override void SetVolumeIndicator(int faderNum, float level)

--- a/NK2Tray/packages.config
+++ b/NK2Tray/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Costura.Fody" version="3.3.0" targetFramework="net461" />
-  <package id="Fody" version="3.3.5" targetFramework="net461" developmentDependency="true" />
-  <package id="NAudio" version="1.8.5" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This is an extension of #56 and allows the application to respond to new MIDI devices without having to restart it.

![image](https://user-images.githubusercontent.com/1736957/81321248-4114f300-908a-11ea-9d80-5a93a5e62e02.png)

It watches MIDI devices coming and going using a set of Windows APIs and re-evaluates the list of devices available to pick from whenever it sees a device added or removed.

**Notable changes**

To get this to nicely, a few updates to the project as a whole were needed. I don't know if these changes will be seen as acceptable or unacceptable, but hopefully the former!

- Moved dependencies from `packages.config` to [PackageReference format](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files). This was required to utilise the new Windows APIs.
- Added a new dependency `Microsoft.Windows.SDK.Contracts@10.0.18362.2005`.

Looking forward to see if anyone can test this out and see if it works for them! 🙂

**Testing**

Because this changes the way packages are referenced, Visual Studio seems to trip over itself a bit if it's used to the solution being configured differently. Therefore, when switching to/from this branch to test, I'd recommend the following:

1. Close any open Visual Studio windows.
2. Pull and check out the branch
3. Open the `NK2Tray.sln` solution
4. Clean the solution (`Build` menu, then `Clean Solution`)
5. Manually delete the `bin` and `obj` folders from the `NK2Tray` directory

From there, you should be able to start debugging/building and it'll pick up the new configuration. This should hopefully work for both switching to this new branch and back to `master` or similar.