### PR TITLE
Fix crash when tray menu is opened right after a fader move

### DIFF
--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AudioDevice.cs" />


### PR DESCRIPTION
If I moved a fader and then immediately right-clicked the tray icon to open the popup menu, the application would crash with the following message:

![image](https://user-images.githubusercontent.com/1736957/81431375-f1512d00-9158-11ea-966b-b87bd1b94fbc.png)

**The easiest way for me to reproduce this was to constantly move a fader/slider and click the icon while I was moving it.**

It looks like a lot of APIs that deal with Windows audio (including [naudio/NAudio](https://github.com/naudio/NAudio)) suffer from thread safety. This issue is caused because the `MMDeviceCollection` has been created on the main thread when the application was booted, but is being accessed by a new thread that's been created when the application was busy processing fader input while a user clicked the tray icon.

To solve this, I've added a single small worker thread that exists only to either set up devices or run the popup, meaning that this same worker thread is always the one that handles the `MMDeviceCollection` list.

---

It looks like it's all working okay, but please test by trying to make the error happen without this fix and then checking that it's resolved with it.

Also, the thread should take essentially zero resources while it's sat waiting to process a menu click, but please do check memory/CPU usage with and without the fix. From what I've seen there has been no difference what-so-ever, but that's only me testing!