### PR TITLE
Fix memory leak - explicitly clean up old menu items when refreshing the list

### DIFF
--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -87,6 +87,12 @@ namespace NK2Tray
         private void OnPopup(object sender, EventArgs e)
         {
             ContextMenu trayMenu = (ContextMenu)sender;
+
+            // Clean old menu items out
+            var oldMenuItems = trayMenu.MenuItems.Cast<MenuItem>().ToArray();
+            foreach (var item in oldMenuItems)
+                item.Dispose();
+
             trayMenu.MenuItems.Clear();
 
             var mixerSessions = audioDevices.GetCachedMixerSessions();


### PR DESCRIPTION
Might be at least a partial solution to #46.

Memory was going up by `~10-20KB` for me every time I opened the menu. Looks like a lot of it was old menu items that were never cleaned up, as they were being held in an `allMenuItems` list internally until `Dispose()` was explicitly called.

Adding this fix gets leaking memory down to a constant `~5KB` instead.