### PR TITLE
Fix program hanging on exit due to worker thread being alive

### DIFF
--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -244,6 +244,7 @@ namespace NK2Tray
         {
             midiDevice.ResetAllLights();
             Application.Exit();
+            _workerDispatcher.InvokeShutdown();
         }
 
     }


### PR DESCRIPTION
I spotted a bug with #58 a little too late, so here's a fix for it.

Currently, if the application is exited, the worker thread used to access the pop-up is still running. This ensures it shuts down properly by using `InvokeShutdown()`.