### PR TITLE
Fix race condition when using logarithmic setting

### DIFF
--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -49,9 +49,6 @@ namespace NK2Tray
             trayIcon.Visible = true;
 
             _workerDispatcher.Invoke(SetupDevice);
-
-            logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
-            SaveLogarithmic();
         }
 
         private Boolean SetupDevice()
@@ -63,6 +60,9 @@ namespace NK2Tray
                 midiDevice = new XtouchMini(audioDevices);
 
             audioDevices.midiDevice = midiDevice;
+
+            logarithmic = System.Convert.ToBoolean(ConfigSaver.GetAppSettings("logarithmic"));
+            SaveLogarithmic();
 
             return midiDevice.Found;
         }


### PR DESCRIPTION
The logarithmic option PR (#50) didn't play very nicely with the crash fix in #58.

This fixes a potential race condition whereby the logarithmic option is trying to initialise before a MIDI device has been selected.