### PR TITLE
Internal `FaderDef` simplification

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -355,7 +355,10 @@ namespace NK2Tray
                 }
 
                 // Select match
-                if (Match(faderNumber, e.MidiEvent, faderDef.selectCode, faderDef.selectOffset, faderDef.selectChannelOverride))
+                if (
+                    faderDef.selectPresent
+                    && Match(faderNumber, e.MidiEvent, faderDef.selectCode, faderDef.selectOffset, faderDef.selectChannelOverride)
+                )
                 {
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;
@@ -382,7 +385,11 @@ namespace NK2Tray
                 }
 
                 // Mute match
-                if (assigned && Match(faderNumber, e.MidiEvent, faderDef.muteCode, faderDef.muteOffset, faderDef.muteChannelOverride))
+                if (
+                    faderDef.mutePresent
+                    && assigned
+                    && Match(faderNumber, e.MidiEvent, faderDef.muteCode, faderDef.muteOffset, faderDef.muteChannelOverride)
+                )
                 {
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;
@@ -395,7 +402,8 @@ namespace NK2Tray
 
                 // Record match
                 if (
-                    assigned
+                    faderDef.recordPresent
+                    && assigned
                     && applicationPath != null
                     && Match(faderNumber, e.MidiEvent, faderDef.recordCode, faderDef.recordOffset, faderDef.recordChannelOverride)
                 )

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -59,30 +59,40 @@ namespace NK2Tray
         public int muteChannelOverride;
         public int recordChannelOverride;
 
-        public FaderDef(bool _delta, float _range, int _channel,
-            bool _selectPresent, bool _mutePresent, bool _recordPresent,
-            int _faderOffset, int _selectOffset, int _muteOffset, int _recordOffset,
-            MidiCommandCode _faderCode, MidiCommandCode _selectCode, MidiCommandCode _muteCode, MidiCommandCode _recordCode,
-            int _faderChannelOverride = -1, int _selectChannelOverride = -1, int _muteChannelOverride = -1, int _recordChannelOverride = -1)
+        public FaderDef(FaderDefOpts opts)
         {
-            delta = _delta;
-            range = _range;
-            channel = _channel;
-            selectPresent = _selectPresent;
-            mutePresent = _mutePresent;
-            recordPresent = _recordPresent;
-            faderOffset = _faderOffset;
-            selectOffset = _selectOffset;
-            muteOffset = _muteOffset;
-            recordOffset = _recordOffset;
-            faderCode = _faderCode;
-            selectCode = _selectCode;
-            muteCode = _muteCode;
-            recordCode = _recordCode;
-            faderChannelOverride = _faderChannelOverride;
-            selectChannelOverride = _selectChannelOverride;
-            muteChannelOverride = _muteChannelOverride;
-            recordChannelOverride = _recordChannelOverride;
+            delta = opts.Delta;
+            range = opts.Range;
+            channel = opts.Channel;
+            
+            faderOffset = opts.Offset;
+            faderCode = opts.Code;
+            faderChannelOverride = -1;
+
+            selectPresent = opts.Select != null;
+            mutePresent = opts.Mute != null;
+            recordPresent = opts.Record != null;
+
+            if (selectPresent)
+            {
+                selectOffset = opts.Select.Offset;
+                selectCode = opts.Select.Code;
+                selectChannelOverride = opts.Select.Channel ?? -1;
+            }
+
+            if (mutePresent)
+            {
+                muteOffset = opts.Mute.Offset;
+                muteCode = opts.Mute.Code;
+                muteChannelOverride = opts.Mute.Channel ?? -1;
+            }
+
+            if (recordPresent)
+            {
+                recordOffset = opts.Record.Offset;
+                recordCode = opts.Record.Code;
+                recordChannelOverride = opts.Record.Channel ?? -1;
+            }
         }
     }
 

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -1,10 +1,43 @@
 ﻿using NAudio.Midi;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace NK2Tray
 {
+    public class FaderDefButtonOpts
+    {
+        public int Offset { get; set; }
+        public MidiCommandCode Code { get; set; }
+        public int? Channel { get; set; }
+
+        public FaderDefButtonOpts()
+        {
+            Offset = 0;
+            Code = MidiCommandCode.NoteOn;
+        }
+    }
+
+    public class FaderDefOpts
+    {
+        public bool Delta { get; set; }
+        public float Range { get; set; }
+        public int Channel { get; set; }
+        public int Offset { get; set; }
+        public MidiCommandCode Code { get; set; }
+        public FaderDefButtonOpts Select { get; set; }
+        public FaderDefButtonOpts Mute { get; set; }
+        public FaderDefButtonOpts Record { get; set; }
+
+        public FaderDefOpts()
+        {
+            Delta = false;
+            Range = 127f;
+            Channel = 1;
+            Offset = 0;
+            Code = MidiCommandCode.ControlChange;
+        }
+    }
+
     public class FaderDef
     {
         public bool delta;

--- a/NK2Tray/MidiDevice.cs
+++ b/NK2Tray/MidiDevice.cs
@@ -35,7 +35,13 @@ namespace NK2Tray
 
         public virtual string SearchString => "wobbo";
 
-        public virtual FaderDef DefaultFaderDef => new FaderDef(false, 1f, 1, true, true, true, 0, 0, 0, 0, MidiCommandCode.ControlChange, MidiCommandCode.ControlChange, MidiCommandCode.ControlChange, MidiCommandCode.ControlChange);
+        public virtual FaderDef DefaultFaderDef => new FaderDef(new FaderDefOpts()
+        {
+            Range = 1f,
+            Select = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange },
+            Mute = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange },
+            Record = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange }
+        });
 
         public MidiDevice()
         {

--- a/NK2Tray/NanoKontrol2.cs
+++ b/NK2Tray/NanoKontrol2.cs
@@ -8,22 +8,14 @@ namespace NK2Tray
     public class NanoKontrol2 : MidiDevice
     {
         public override string SearchString => "nano";
-        public override FaderDef DefaultFaderDef => new FaderDef(
-            false, // delta
-            127f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            true,  // recordPresent
-            0,     // faderOffset
-            32,    // selectOffset
-            48,    // muteOffset
-            64,    // recordOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.ControlChange, // selectCode
-            MidiCommandCode.ControlChange, // muteCode
-            MidiCommandCode.ControlChange // recordCode
-        );
+
+        public override FaderDef DefaultFaderDef => new FaderDef(new FaderDefOpts()
+        {
+            Range = 127f,
+            Select = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange, Offset = 32 },
+            Mute = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange, Offset = 48 },
+            Record = new FaderDefButtonOpts() { Code = MidiCommandCode.ControlChange, Offset = 64 }
+        });
 
         public NanoKontrol2(AudioDevice audioDev)
         {

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -9,57 +9,33 @@ namespace NK2Tray
     public class XtouchMini : MidiDevice
     {
         public override string SearchString => "x-touch mini";
-        public override FaderDef DefaultFaderDef => new FaderDef(
-            true,  // delta
-            64f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            false, // recordPresent
-            16,    // faderOffset
-            32,    // selectOffset
-            38,    // muteOffset
-            0,     // recordOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.NoteOn,        // selectCode
-            MidiCommandCode.NoteOn,        // muteCode
-            MidiCommandCode.ControlChange  // recordCode
-        );
 
-        public FaderDef FirstTwoFaderDef => new FaderDef(
-            true,  // delta
-            64f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            false, // recordPresent
-            16,    // faderOffset
-            32,    // selectOffset
-            89,    // muteOffset
-            0,     // recordOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.NoteOn,        // selectCode
-            MidiCommandCode.NoteOn,        // muteCode
-            MidiCommandCode.ControlChange  // recordCode
-        );
+        public override FaderDef DefaultFaderDef => new FaderDef(new FaderDefOpts()
+        {
+            Delta = true,
+            Range = 64f,
+            Offset = 16,
+            Select = new FaderDefButtonOpts() { Offset = 32 },
+            Mute = new FaderDefButtonOpts() { Offset = 38 }
+        });
 
-        public FaderDef MasterFaderDef => new FaderDef(
-            false,  // delta
-            16256f, // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            false,  // recordPresent
-            0,      // faderOffset
-            76,     // selectOffset
-            77,     // muteOffset
-            0,      // recordOffset
-            MidiCommandCode.PitchWheelChange, // faderCode
-            MidiCommandCode.NoteOn,           // selectCode
-            MidiCommandCode.NoteOn,           // muteCode
-            MidiCommandCode.ControlChange,    // recordCode
-            9      // faderChannelOverride
-        );
+        public FaderDef FirstTwoFaderDef => new FaderDef(new FaderDefOpts()
+        {
+            Delta = true,
+            Range = 64f,
+            Offset = 16,
+            Select = new FaderDefButtonOpts() { Offset = 32 },
+            Mute = new FaderDefButtonOpts() { Offset = 89 }
+        });
+
+        public FaderDef MasterFaderDef => new FaderDef(new FaderDefOpts()
+        {
+            Range = 16256f,
+            Channel = 9,
+            Code = MidiCommandCode.PitchWheelChange,
+            Select = new FaderDefButtonOpts() { Offset = 76, Channel = 1 },
+            Mute = new FaderDefButtonOpts() { Offset = 77, Channel = 1 }
+        });
 
         public XtouchMini(AudioDevice audioDev)
         {


### PR DESCRIPTION
From creating new profiles for other MIDI controllers, mapping the right values to `FaderDef` instances was pretty confusing. There was also a bug whereby a button was still trying to be processed even though it was being marked as _not present_.

This PR hopefully simplifies fader definition some. The previous implementation _required at least 14 separate arguments_! Here are some examples of new `FaderDef` instances with the new constructor:

``` c#
// Slider, 0 - 127, channel 1, offset 0, no buttons
new FaderDef(new FaderDefOpts());

// Slider, 0 - 256, channel 5, offset 0, mute button with offset 5
new FaderDef(new FaderDefOpts()
{
    Range = 256f,
    Channel = 5,
    Mute = new FaderDefButtonOpts(){ Offset = 5 }
});

// Infinite rotary, 0 - 64, channel 1, offset 3, mute, select buttons
new FaderDef(new FaderDefOpts()
{
    Delta = true,
    Range = 64f,
    Offset = 3,
    Mute = new FaderDefButtonOpts(){ Offset = 32 },
    Select = new FaderDefButtonOpts(){ Offset = 33, Code = MIDICommandCode.ControlChange }
});
```

For reference, here's what those same definitions would look like with the current constructor:

``` c#
// Slider, 0 - 127, channel 1, offset 0, no buttons
new FaderDef(false, 127f, 1, false, false, false, 0, 0, 0, 0, MIDICommandCode.ControlChange, MIDICommandCode.NoteOn, MIDICommandCode.NoteOn, MIDICommandCode.NoteOn);

// Slider, 0 - 256, channel 5, offset 0, mute button with offset 5
new FaderDef(false, 256f, 5, false, true, false, 0, 0, 5, 0, MIDICommandCode.ControlChange, MIDICommandCode.NoteOn, MIDICommandCode.NoteOn, MIDICommandCode.NoteOn);

// Infinite rotary, 0 - 64, channel 1, offset 3, mute, record buttons
new FaderDef(true, 64f, 1, false, true, true, 3, 0, 32, 33, MIDICommandCode.ControlChange, MIDICommandCode.NoteOn, MIDICommandCode.ControlChange, MIDICommandCode.NoteOn, -1, -1, -1, 9);
```

This PR includes updating the currently-supported devices too, so please test them out!