### PR TITLE
Synchronise mute/volume indicators

### DIFF
--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -368,9 +368,7 @@ namespace NK2Tray
                             nextStepIndex = Math.Min(nearestStep + 1, steps.Length - 1);
 
                         newVol = steps[nextStepIndex];
-
                         assignment.SetVolume(newVol);
-                        parent.SetVolumeIndicator(faderNumber, newVol);
                     }
                     else
                     {
@@ -385,16 +383,8 @@ namespace NK2Tray
                         return true;
                     }
 
-                    // see if we need to set any other volume indicators
-                    foreach (var fader in parent.faders)
-                    {
-                        if (fader.faderNumber == faderNumber) continue;
-                        if (!fader.faderDef.delta) continue;
-                        if (fader.assignment == null) continue;
-                        if (fader.assignment.label != assignment.label) continue;
-
-                        fader.parent.SetVolumeIndicator(fader.faderNumber, newVol);
-                    }
+                    List<Fader> fadersToAffect = GetMatchingFaders();
+                    fadersToAffect.ForEach(fader => fader.parent.SetVolumeIndicator(fader.faderNumber, newVol));
 
                     return true;
                 }
@@ -442,15 +432,8 @@ namespace NK2Tray
                         return true;
                     }
 
-                    // see if we need to illuminate any other lights
-                    foreach (var fader in parent.faders)
-                    {
-                        if (fader.faderNumber == faderNumber) continue;
-                        if (fader.assignment == null) continue;
-                        if (fader.assignment.label != assignment.label) continue;
-
-                        fader.SetMuteLight(muteStatus);
-                    }
+                    List<Fader> fadersToAffect = GetMatchingFaders();
+                    fadersToAffect.ForEach(fader => fader.SetMuteLight(muteStatus));
 
                     return true;
                 }

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -281,6 +281,8 @@ namespace NK2Tray
                         assignment = newAssignment;
                     }
 
+                    float newVol;
+
                     if (faderDef.delta)
                     {
                         var val = GetValue(e.MidiEvent);
@@ -295,18 +297,34 @@ namespace NK2Tray
                         else
                             nextStepIndex = Math.Min(nearestStep + 1, steps.Length - 1);
 
-                        var newVol = steps[nextStepIndex];
+                        newVol = steps[nextStepIndex];
 
                         assignment.SetVolume(newVol);
                         parent.SetVolumeIndicator(faderNumber, newVol);
                     }
                     else
                     {
-                        assignment.SetVolume(getVolFromStage(GetValue(e.MidiEvent)));
+                        newVol = getVolFromStage(GetValue(e.MidiEvent));
+                        assignment.SetVolume(newVol);
                     }
 
                     if (assignment.IsDead())
+                    {
                         SetRecordLight(true);
+
+                        return true;
+                    }
+
+                    // see if we need to set any other volume indicators
+                    foreach (var fader in parent.faders)
+                    {
+                        if (fader.faderNumber == faderNumber) continue;
+                        if (!fader.faderDef.delta) continue;
+                        if (fader.assignment == null) continue;
+                        if (fader.assignment.label != assignment.label) continue;
+
+                        fader.parent.SetVolumeIndicator(fader.faderNumber, newVol);
+                    }
 
                     return true;
                 }

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -362,9 +362,26 @@ namespace NK2Tray
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;
 
-                    SetMuteLight(assignment.ToggleMute());
+                    var muteStatus = assignment.ToggleMute();
+                    SetMuteLight(muteStatus);
+
                     if (assignment.IsDead())
+                    {
                         SetRecordLight(true);
+
+                        return true;
+                    }
+
+                    // see if we need to illuminate any other lights
+                    foreach (var fader in parent.faders)
+                    {
+                        if (fader.faderNumber == faderNumber) continue;
+                        if (fader.assignment == null) continue;
+                        if (fader.assignment.label != assignment.label) continue;
+
+                        fader.SetMuteLight(muteStatus);
+                    }
+
                     return true;
                 }
 

--- a/NK2Tray/MixerSession.cs
+++ b/NK2Tray/MixerSession.cs
@@ -308,5 +308,16 @@ namespace NK2Tray
 
             return targetAudioSessions.First().SimpleAudioVolume.Mute;
         }
+
+        public bool HasCrossoverProcesses(MixerSession other)
+        {
+            if (other == null) return false;
+
+            return audioSessions.Any(session =>
+                other.audioSessions.Any(otherSession =>
+                    session.GetProcessID == otherSession.GetProcessID
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
If two sliders are set to the same input (or one is set to, say, Spotify, and you move a Focus slider while focusing on Spotify), only the active fader moves. This PR should address that, ensuring that the interlinked volume and mute indicators on the board stay in harmony!

This is particularly cool for the X-TOUCH MINI at the moment, as moving the slider can change the volume indicators on the rotary knobs in real-time!

**Tested situations**

- `Application <-> Application`
- `Focus <-> Application`
- `Master <-> Master`
- `SystemSounds <-> SystemSounds`

**Notable changes**

- Added `MixerSession::HasCrossoverProcesses(MixerSession other)` which checks if any session processes from the current session match any from the `other`.
- Added `Fader::GetMatchingFaders()`, which gets all faders on the board that match the current one, either via `MixerSession::HasCrossoverProcesses(MixerSession other)` or other methods for differing `SessionType`s.

It's a bit easier to test the extent of this on the X-TOUCH MINI, but the NK2 should be happily syncing mute button status too!