### PR TITLE
🎹 Support for the EasyControl.9 MIDI Controller

### DIFF
--- a/NK2Tray/EasyControl.cs
+++ b/NK2Tray/EasyControl.cs
@@ -16,7 +16,7 @@ namespace NK2Tray
             false,  // recordPresent
             14,     // faderOffset
             23,    // selectOffset
-            9,    // muteOffset
+            23,    // muteOffset
             64,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
@@ -33,7 +33,7 @@ namespace NK2Tray
             false,  // recordPresent
             14,     // faderOffset
             23,    // selectOffset
-            10,    // muteOffset
+            24,    // muteOffset
             64,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode

--- a/NK2Tray/EasyControl.cs
+++ b/NK2Tray/EasyControl.cs
@@ -15,9 +15,9 @@ namespace NK2Tray
             true,  // mutePresent
             false,  // recordPresent
             14,     // faderOffset
-            23,    // selectOffset
+            0,    // selectOffset
             23,    // muteOffset
-            64,    // recordOffset
+            0,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
             MidiCommandCode.ControlChange, // muteCode
@@ -32,9 +32,9 @@ namespace NK2Tray
             true,  // mutePresent
             false,  // recordPresent
             14,     // faderOffset
-            23,    // selectOffset
+            0,    // selectOffset
             24,    // muteOffset
-            64,    // recordOffset
+            0,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
             MidiCommandCode.ControlChange, // muteCode
@@ -51,7 +51,7 @@ namespace NK2Tray
             1,     // faderOffset
             55,    // selectOffset
             58,    // muteOffset
-            64,    // recordOffset
+            0,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
             MidiCommandCode.ControlChange, // muteCode

--- a/NK2Tray/EasyControl.cs
+++ b/NK2Tray/EasyControl.cs
@@ -1,0 +1,92 @@
+﻿using NAudio.Midi;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NK2Tray
+{
+    public class EasyControl : MidiDevice
+    {
+        public override string SearchString => "easy";
+        public override FaderDef DefaultFaderDef => new FaderDef(
+            false, // delta
+            127f,   // range
+            1,     // channel
+            false,  // selectPresent
+            true,  // mutePresent
+            false,  // recordPresent
+            0,     // faderOffset
+            23,    // selectOffset
+            48,    // muteOffset
+            64,    // recordOffset
+            MidiCommandCode.ControlChange, // faderCode
+            MidiCommandCode.ControlChange, // selectCode
+            MidiCommandCode.ControlChange, // muteCode
+            MidiCommandCode.ControlChange // recordCode
+        );
+
+        public FaderDef HorizntalFaderDef => new FaderDef(
+            false, // delta
+            127f,   // range
+            1,     // channel
+            false,  // selectPresent
+            true,  // mutePresent
+            false,  // recordPresent
+            0,     // faderOffset
+            23,    // selectOffset
+            -8,    // muteOffset
+            64,    // recordOffset
+            MidiCommandCode.ControlChange, // faderCode
+            MidiCommandCode.ControlChange, // selectCode
+            MidiCommandCode.ControlChange, // muteCode
+            MidiCommandCode.ControlChange // recordCode
+        );
+
+        public EasyControl(AudioDevice audioDev)
+        {
+            audioDevices = audioDev;
+            FindMidiIn();
+            FindMidiOut();
+            if (Found)
+            {
+                ResetAllLights();
+                InitFaders();
+                InitButtons();
+                LoadAssignments();
+                ListenForMidi();
+            }
+        }
+
+        public override void ResetAllLights()
+        {
+            foreach (var i in Enumerable.Range(0, 128))
+                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)i, 0).GetAsShortMessage());
+        }
+
+        public override void SetLight(int controller, bool state)
+        {
+            midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(controller), state ? 127 : 0).GetAsShortMessage());
+        }
+
+        public override void InitFaders()
+        {
+            faders = new List<Fader>();
+
+            foreach (var i in Enumerable.Range(0, 10))
+            {
+                Fader fader = (i < 9) ? new Fader(this, i) : new Fader(this, i, this.HorizntalFaderDef);
+                fader.ResetLights();
+                faders.Add(fader);
+            }
+        }
+
+        public override void InitButtons()
+        {
+            buttons = new List<Button>();
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPrevious, 47, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaNext,     48, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaStop,     46, false));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPlay,     45, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaRecord,   44, false));
+        }
+    }
+}

--- a/NK2Tray/EasyControl.cs
+++ b/NK2Tray/EasyControl.cs
@@ -7,16 +7,16 @@ namespace NK2Tray
     public class EasyControl : MidiDevice
     {
         public override string SearchString => "easy";
-        public override FaderDef DefaultFaderDef => new FaderDef(
+        public FaderDef FirstFourFaderDef => new FaderDef(
             false, // delta
             127f,   // range
             1,     // channel
             false,  // selectPresent
             true,  // mutePresent
             false,  // recordPresent
-            0,     // faderOffset
+            14,     // faderOffset
             23,    // selectOffset
-            48,    // muteOffset
+            9,    // muteOffset
             64,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
@@ -24,17 +24,51 @@ namespace NK2Tray
             MidiCommandCode.ControlChange // recordCode
         );
 
-        public FaderDef HorizntalFaderDef => new FaderDef(
+        public FaderDef SecondFiveFaderDef => new FaderDef(
             false, // delta
             127f,   // range
             1,     // channel
             false,  // selectPresent
             true,  // mutePresent
             false,  // recordPresent
-            0,     // faderOffset
+            14,     // faderOffset
             23,    // selectOffset
-            -8,    // muteOffset
+            10,    // muteOffset
             64,    // recordOffset
+            MidiCommandCode.ControlChange, // faderCode
+            MidiCommandCode.ControlChange, // selectCode
+            MidiCommandCode.ControlChange, // muteCode
+            MidiCommandCode.ControlChange // recordCode
+        );
+
+        public FaderDef KnobFaderDef => new FaderDef(
+            false, // delta
+            127f,   // range
+            1,     // channel
+            true,  // selectPresent
+            true,  // mutePresent
+            false,  // recordPresent
+            1,     // faderOffset
+            55,    // selectOffset
+            58,    // muteOffset
+            64,    // recordOffset
+            MidiCommandCode.ControlChange, // faderCode
+            MidiCommandCode.ControlChange, // selectCode
+            MidiCommandCode.ControlChange, // muteCode
+            MidiCommandCode.ControlChange // recordCode
+        );
+
+        public FaderDef HorizontalFaderDef => new FaderDef(
+            false, // delta
+            127f,   // range
+            1,     // channel
+            true,  // selectPresent
+            true,  // mutePresent
+            true,  // recordPresent
+            -1,     // faderOffset
+            -8,    // selectOffset
+            -9,    // muteOffset
+            17,    // recordOffset
             MidiCommandCode.ControlChange, // faderCode
             MidiCommandCode.ControlChange, // selectCode
             MidiCommandCode.ControlChange, // muteCode
@@ -46,6 +80,7 @@ namespace NK2Tray
             audioDevices = audioDev;
             FindMidiIn();
             FindMidiOut();
+
             if (Found)
             {
                 ResetAllLights();
@@ -71,22 +106,31 @@ namespace NK2Tray
         {
             faders = new List<Fader>();
 
-            foreach (var i in Enumerable.Range(0, 10))
+            foreach (var i in Enumerable.Range(0, 11))
             {
-                Fader fader = (i < 9) ? new Fader(this, i) : new Fader(this, i, this.HorizntalFaderDef);
+                Fader fader = new Fader(this, i, SelectFaderDef(i));
                 fader.ResetLights();
                 faders.Add(fader);
             }
         }
 
+        public FaderDef SelectFaderDef(int faderNum)
+        {
+            if (faderNum < 4) return FirstFourFaderDef;
+            if (faderNum < 9) return SecondFiveFaderDef;
+            if (faderNum == 9) return KnobFaderDef;
+
+            return HorizontalFaderDef;
+        }
+
         public override void InitButtons()
         {
             buttons = new List<Button>();
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPrevious, 47, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaNext,     48, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaStop,     46, false));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPlay,     45, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaRecord,   44, false));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPrevious, 34, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaNext,     35, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaStop,     36, false));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPlay,     37, true));
+            buttons.Add(new Button(ref midiOut,  ButtonType.MediaRecord,   38, false));
         }
     }
 }

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -312,7 +312,10 @@ namespace NK2Tray
                 }
 
                 // Select match
-                if (Match(faderNumber, e.MidiEvent, faderDef.selectCode, faderDef.selectOffset, faderDef.selectChannelOverride))
+                if (
+                    faderDef.selectPresent
+                    && Match(faderNumber, e.MidiEvent, faderDef.selectCode, faderDef.selectOffset, faderDef.selectChannelOverride)
+                )
                 {
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;
@@ -339,7 +342,11 @@ namespace NK2Tray
                 }
 
                 // Mute match
-                if (assigned && Match(faderNumber, e.MidiEvent, faderDef.muteCode, faderDef.muteOffset, faderDef.muteChannelOverride))
+                if (
+                    faderDef.mutePresent
+                    && assigned
+                    && Match(faderNumber, e.MidiEvent, faderDef.muteCode, faderDef.muteOffset, faderDef.muteChannelOverride)
+                )
                 {
                     if (GetValue(e.MidiEvent) != 127) // Only on button-down
                         return true;
@@ -352,7 +359,8 @@ namespace NK2Tray
 
                 // Record match
                 if (
-                    assigned
+                    faderDef.recordPresent
+                    && assigned
                     && applicationPath != null
                     && Match(faderNumber, e.MidiEvent, faderDef.recordCode, faderDef.recordOffset, faderDef.recordChannelOverride)
                 )

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Button.cs" />
     <Compile Include="ConfigSaver.cs" />
     <Compile Include="DevicePathMapper.cs" />
+    <Compile Include="EasyControl.cs" />
     <Compile Include="Fader.cs" />
     <Compile Include="IconExtractor.cs" />
     <Compile Include="MediaTools.cs" />

--- a/NK2Tray/Program.cs
+++ b/NK2Tray/Program.cs
@@ -56,8 +56,12 @@ namespace NK2Tray
             audioDevices = new AudioDevice();
 
             midiDevice = new NanoKontrol2(audioDevices);
+
             if (!midiDevice.Found)
                 midiDevice = new XtouchMini(audioDevices);
+
+            if (!midiDevice.Found)
+                midiDevice = new EasyControl(audioDevices);
 
             audioDevices.midiDevice = midiDevice;
 


### PR DESCRIPTION
This is a profile for the EasyControl.9 MIDI Controller. Its usual brand name is "_Worlde_", though it appears that it's also commonly resold as "_ammoon_", "_SubZero_", _"Omnitronic_", and probably a few more.

![image](https://user-images.githubusercontent.com/1736957/81507386-ffd44b80-92f4-11ea-9f5b-0a34b0a8750d.png)

#63 and #57 will slightly change the implementation here, so this branch can be rebased if they get merged beforehand.

**Utilised hardware:**

- Play/Stop/Next/Prev media keys
- Vertical faders 1 - 9 with mute button below included
- Knob as fader 10 with mute button to the left and select button to the right
- Horizontal slider as fader 11 with left button below as mute and right button as select

**Ugliness**

There was some confusion trying to set this up (Discord user `@mrnorrisman` helped wonderfully with this). It appears that in its default state, the EasyControl.9 knob is set to `CC#10` and the horizontal slider to `CC#9`. These can't be changed. Insanely, however, `CC#9` and `CC#10` are also used by vertical sliders 7 and 8 in its default configuration.

After finding a few YouTube videos that also attest to this fact, it seems the only way around this is to reconfigure the controller (using software provided by _Worlde_) to assign sensible `CC#`s to all the inputs. The following image shows the desired set-up in the editor software.

![image](https://user-images.githubusercontent.com/1736957/81507541-162ed700-92f6-11ea-87fd-d6850771b088.png)

Because of this extra step required, it might be worth setting up a separate `DEVICES.md` file that show supported devices, what they currently support, and how to use them. In this particular instance we can actually provide a `.Ctrl_data` file (zipped below) that can be imported in the software, or we could just show the image above.

[NK2TrayProfile.zip](https://github.com/ho0ber/NK2Tray/files/4606528/NK2TrayProfile.zip)


