### PR TITLE
Rework of MidiDevice & device chooser

### DIFF
--- a/NK2Tray/Button.cs
+++ b/NK2Tray/Button.cs
@@ -22,25 +22,32 @@ namespace NK2Tray
         public int controller;
         public MidiCommandCode commandCode;
         public int channel;
-        public MidiOut midiOut;
+        public MidiDevice midiDevice;
 
-        public Button(ref MidiOut midiOutRef, ButtonType butType, int cont, bool initialState, MidiCommandCode code=MidiCommandCode.ControlChange)
+        public Button(MidiDevice midiDeviceRef, ButtonType butType, int cont, bool initialState, MidiCommandCode code=MidiCommandCode.ControlChange)
         {
+            midiDevice = midiDeviceRef;
             commandCode = code;
             channel = 1;
             buttonType = butType;
             controller = cont;
-            midiOut = midiOutRef;
             SetLight(initialState);
         }
 
         public void SetLight(bool state)
         {
             light = state;
-            if (commandCode == MidiCommandCode.ControlChange)
-                midiOut.Send(new ControlChangeEvent(0, channel, (MidiController)(controller), state ? 127 : 0).GetAsShortMessage());
-            else if (commandCode == MidiCommandCode.NoteOn)
-                midiOut.Send(new NoteOnEvent(0, 1, controller, state ? 127 : 0, 0).GetAsShortMessage());
+            refreshLight();
+        }
+
+        public void refreshLight()
+        {
+            midiDevice.SetLight(controller, light);
+        }
+
+        public void SetLightTemp(bool state)
+        {
+            midiDevice.SetLight(controller, state);
         }
 
         public bool HandleEvent(MidiInMessageEventArgs e, MidiDevice device)

--- a/NK2Tray/EasyControl.cs
+++ b/NK2Tray/EasyControl.cs
@@ -4,145 +4,116 @@ using System.Linq;
 
 namespace NK2Tray
 {
-    public class EasyControl : MidiDevice
+    public class EasyControl : MidiDeviceTemplate
     {
-        public override string SearchString => "easy";
-        public FaderDef FirstFourFaderDef => new FaderDef(
-            false, // delta
-            127f,   // range
-            1,     // channel
-            false,  // selectPresent
-            true,  // mutePresent
-            false,  // recordPresent
-            false, // subfaderPresent
-            14,     // faderOffset
-            0,    // selectOffset
-            23,    // muteOffset
-            0,    // recordOffset
-            0,    // subFaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.ControlChange, // selectCode
-            MidiCommandCode.ControlChange, // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
+        public override bool hasLights => true;
+        public override int lightCount => 128;
+        public override MidiCommandCode lightMessageType => MidiCommandCode.ControlChange;
+        public override bool hasVolumeIndicator => false;
+        public override int fadersCount => 11;
 
-        public FaderDef SecondFiveFaderDef => new FaderDef(
-            false, // delta
-            127f,   // range
-            1,     // channel
-            false,  // selectPresent
-            true,  // mutePresent
-            false,  // recordPresent
-            false,  // subfaderPresent
-            14,     // faderOffset
-            0,    // selectOffset
-            24,    // muteOffset
-            0,    // recordOffset
-            0,    // subfaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.ControlChange, // selectCode
-            MidiCommandCode.ControlChange, // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
-
-        public FaderDef KnobFaderDef => new FaderDef(
-            false, // delta
-            127f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            false,  // recordPresent
-            false,  // subfaderPresent
-            1,     // faderOffset
-            55,    // selectOffset
-            58,    // muteOffset
-            0,    // recordOffset
-            0,    // subfaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.ControlChange, // selectCode
-            MidiCommandCode.ControlChange, // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
-
-        public FaderDef HorizontalFaderDef => new FaderDef(
-            false, // delta
-            127f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            true,  // recordPresent
-            false, // subfaderPresent
-            -1,     // faderOffset
-            -8,    // selectOffset
-            -9,    // muteOffset
-            17,    // recordOffset
-            0,     // subfaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.ControlChange, // selectCode
-            MidiCommandCode.ControlChange, // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
-
-        public EasyControl(AudioDevice audioDev)
+        public override Button[] buttons => new Button[]
         {
-            audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
+            new Button(midiDevice, ButtonType.MediaPrevious, 34, true),
+            new Button(midiDevice, ButtonType.MediaNext,     35, true),
+            new Button(midiDevice, ButtonType.MediaStop,     36, false),
+            new Button(midiDevice, ButtonType.MediaPlay,     37, true),
+            new Button(midiDevice, ButtonType.MediaRecord,   38, false)
+        };
 
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LoadAssignments();
-                ListenForMidi();
-            }
+        //public override string SearchString => "easy";
+
+        public override FaderDef[] faderDefs => new FaderDef[]{
+            new FaderDef( //FirstFourFaderDef
+                false, // delta
+                127f,   // range
+                1,     // channel
+                false,  // selectPresent
+                true,  // mutePresent
+                false,  // recordPresent
+                false, // subfaderPresent
+                14,     // faderOffset
+                0,    // selectOffset
+                23,    // muteOffset
+                0,    // recordOffset
+                0,    // subFaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.ControlChange, // selectCode
+                MidiCommandCode.ControlChange, // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            ),
+            new FaderDef( //SecondFiveFaderDef
+                false, // delta
+                127f,   // range
+                1,     // channel
+                false,  // selectPresent
+                true,  // mutePresent
+                false,  // recordPresent
+                false,  // subfaderPresent
+                14,     // faderOffset
+                0,    // selectOffset
+                24,    // muteOffset
+                0,    // recordOffset
+                0,    // subfaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.ControlChange, // selectCode
+                MidiCommandCode.ControlChange, // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            ),
+            new FaderDef( //KnobFaderDef
+                false, // delta
+                127f,   // range
+                1,     // channel
+                true,  // selectPresent
+                true,  // mutePresent
+                false,  // recordPresent
+                false,  // subfaderPresent
+                1,     // faderOffset
+                55,    // selectOffset
+                58,    // muteOffset
+                0,    // recordOffset
+                0,    // subfaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.ControlChange, // selectCode
+                MidiCommandCode.ControlChange, // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            ),
+            new FaderDef( //HorizontalFaderDef
+                false, // delta
+                127f,   // range
+                1,     // channel
+                true,  // selectPresent
+                true,  // mutePresent
+                true,  // recordPresent
+                false, // subfaderPresent
+                -1,     // faderOffset
+                -8,    // selectOffset
+                -9,    // muteOffset
+                17,    // recordOffset
+                0,     // subfaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.ControlChange, // selectCode
+                MidiCommandCode.ControlChange, // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            )
+        };
+
+        public EasyControl(MidiDevice midiDev) : base(midiDev)
+        {
+
         }
 
-        public override void ResetAllLights()
+        public override int SelectFaderDef(int faderNum)
         {
-            foreach (var i in Enumerable.Range(0, 128))
-                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)i, 0).GetAsShortMessage());
-        }
+            if (faderNum < 4) return 0; //FirstFourFaderDef
+            if (faderNum < 9) return 1; //SecondFiveFaderDef
+            if (faderNum == 9) return 2; //KnobFaderDef
 
-        public override void SetLight(int controller, bool state)
-        {
-            midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(controller), state ? 127 : 0).GetAsShortMessage());
-        }
-
-        public override void InitFaders()
-        {
-            faders = new List<Fader>();
-
-            foreach (var i in Enumerable.Range(0, 11))
-            {
-                Fader fader = new Fader(this, i, SelectFaderDef(i));
-                fader.ResetLights();
-                faders.Add(fader);
-            }
-        }
-
-        public FaderDef SelectFaderDef(int faderNum)
-        {
-            if (faderNum < 4) return FirstFourFaderDef;
-            if (faderNum < 9) return SecondFiveFaderDef;
-            if (faderNum == 9) return KnobFaderDef;
-
-            return HorizontalFaderDef;
-        }
-
-        public override void InitButtons()
-        {
-            buttons = new List<Button>();
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPrevious, 34, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaNext,     35, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaStop,     36, false));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPlay,     37, true));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaRecord,   38, false));
+            return 3; //HorizontalFaderDef
         }
     }
 }

--- a/NK2Tray/Fader.cs
+++ b/NK2Tray/Fader.cs
@@ -85,14 +85,14 @@ namespace NK2Tray
         public float faderPositionMultiplier;
         private int primaryFaderHardwareValue;
 
-        public Fader(MidiDevice midiDevice, int faderNum)
+        /*public Fader(MidiDevice midiDevice, int faderNum)
         {
             parent = midiDevice;
             midiOut = midiDevice.midiOut;
             faderNumber = faderNum;
             faderDef = parent.DefaultFaderDef;
             SetCurve(1f);
-        }
+        }*/
 
         public Fader(MidiDevice midiDevice, int faderNum, FaderDef _faderDef)
         {
@@ -211,6 +211,20 @@ namespace NK2Tray
         {
             recordLight = state;
             parent.SetLight(recordController, state);
+        }
+
+        public void SetLightTemp(bool state)
+        {
+            parent.SetLight(selectController, state);
+            parent.SetLight(muteController, state);
+            parent.SetLight(recordController, state);
+        }
+
+        public void refreshLights()
+        {
+            parent.SetLight(selectController, selectLight);
+            parent.SetLight(muteController, muteLight);
+            parent.SetLight(recordController, recordLight);
         }
 
         public bool GetSelectLight() { return selectLight; }

--- a/NK2Tray/MidiDeviceTemplate.cs
+++ b/NK2Tray/MidiDeviceTemplate.cs
@@ -1,0 +1,40 @@
+﻿using NAudio.Midi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NK2Tray
+{
+
+    public class MidiDeviceTemplate
+    {
+        public virtual bool hasLights => false;
+        public virtual int lightCount => 0;
+        public virtual MidiCommandCode lightMessageType => MidiCommandCode.ControlChange;
+        public virtual bool hasVolumeIndicator => false;
+
+        public virtual int fadersCount => 0;
+
+        public virtual Button[] buttons => new Button[0];
+        public virtual FaderDef[] faderDefs => new FaderDef[0];
+
+        public MidiDevice midiDevice;
+
+
+        public MidiDeviceTemplate(MidiDevice midiDev)
+        {
+            midiDevice = midiDev;
+        }
+
+        public virtual void LightShow(ref List<Fader> faders){}
+
+        public virtual void ResetSuppLights(MidiOut midiOut){}
+
+        public virtual int SelectFaderDef(int fader)
+        {
+            return 0;
+        }
+    }
+}

--- a/NK2Tray/NK2Tray.csproj
+++ b/NK2Tray/NK2Tray.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Fader.cs" />
     <Compile Include="IconExtractor.cs" />
     <Compile Include="MediaTools.cs" />
+    <Compile Include="MidiDeviceTemplate.cs" />
     <Compile Include="NanoKontrol2.cs" />
     <Compile Include="MidiDevice.cs" />
     <Compile Include="MixerSession.cs" />

--- a/NK2Tray/OP1.cs
+++ b/NK2Tray/OP1.cs
@@ -5,133 +5,108 @@ using System.Linq;
 
 namespace NK2Tray
 {
-    public class OP1 : MidiDevice
+    public class OP1 : MidiDeviceTemplate
     {
-        public override string SearchString => "op-1";
+        public override bool hasLights => false;
+        //public override int lightCount => 128;
+        //public override MidiCommandCode lightMessageType => MidiCommandCode.ControlChange;
+        //public override bool hasVolumeIndicator => false;
 
-        public FaderDef FirstFader => new FaderDef(
-            false,   // delta
-            127f,    // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            true,  // recordPresent
-            false, // subFaderPresent
-            1,      // faderOffset
-            64,     // selectOffset
-            50,     // muteOffset
-            51,     // recordOffset
-            0,      // subFaderOffset
-            MidiCommandCode.ControlChange,  // faderCode
-            MidiCommandCode.ControlChange,  // selectCode
-            MidiCommandCode.ControlChange,  // muteCode
-            MidiCommandCode.ControlChange,  // recordCode
-            MidiCommandCode.ControlChange   // subFaderCode
-        );
+        public override int fadersCount => 4;
 
-        public FaderDef SecondFader => new FaderDef(
-            false,   // delta
-            127f,    // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            true,  // recordPresent
-            false, // subFaderPresent
-            1,      // faderOffset
-            64,     // selectOffset
-            51,     // muteOffset
-            20,     // recordOffset
-            0,      // subFaderOffset
-            MidiCommandCode.ControlChange,  // faderCode
-            MidiCommandCode.ControlChange,  // selectCode
-            MidiCommandCode.ControlChange,  // muteCode
-            MidiCommandCode.ControlChange,  // recordCode
-            MidiCommandCode.ControlChange   // subFaderCode
-        );
-
-        public FaderDef ThirdFader => new FaderDef(
-            false,   // delta
-            127f,    // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            true,  // recordPresent
-            false, // subFaderPresent
-            1,      // faderOffset
-            64,     // selectOffset
-            20,     // muteOffset
-            21,     // recordOffset
-            0,      // subFaderOffset
-            MidiCommandCode.ControlChange,  // faderCode
-            MidiCommandCode.ControlChange,  // selectCode
-            MidiCommandCode.ControlChange,  // muteCode
-            MidiCommandCode.ControlChange,  // recordCode
-            MidiCommandCode.ControlChange   // subFaderCode
-        );
-
-        public FaderDef FourthFader => new FaderDef(
-            false,   // delta
-            127f,    // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            true,  // recordPresent
-            false,  // subFaderPresent
-            1,      // faderOffset
-            64,     // selectOffset
-            21,     // muteOffset
-            22,     // recordOffset
-            0,      // subFaderOffset
-            MidiCommandCode.ControlChange,  // faderCode
-            MidiCommandCode.ControlChange,  // selectCode
-            MidiCommandCode.ControlChange,  // muteCode
-            MidiCommandCode.ControlChange,  // recordCode
-            MidiCommandCode.ControlChange   // subFaderCode
-        );
-
-        public OP1(AudioDevice audioDev)
+        public override Button[] buttons => new Button[]
         {
-            audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
+            new Button(midiDevice, ButtonType.MediaPlay, 39, true),
+            new Button(midiDevice, ButtonType.MediaStop, 40, false),
+            new Button(midiDevice, ButtonType.MediaNext, 16, true),
+            new Button(midiDevice, ButtonType.MediaPrevious, 15, true)
+        };
 
-            if (Found)
-            {
-                InitFaders();
-                InitButtons();
-                LoadAssignments();
-                ListenForMidi();
-            }
-        }
+        //public override string SearchString => "op-1";
 
-        public override void InitFaders()
+        public override FaderDef[] faderDefs => new FaderDef[]{
+            new FaderDef(
+                false,   // delta
+                127f,    // range
+                1,      // channel
+                true,   // selectPresent
+                true,   // mutePresent
+                true,  // recordPresent
+                false, // subFaderPresent
+                1,      // faderOffset
+                64,     // selectOffset
+                50,     // muteOffset
+                51,     // recordOffset
+                0,      // subFaderOffset
+                MidiCommandCode.ControlChange,  // faderCode
+                MidiCommandCode.ControlChange,  // selectCode
+                MidiCommandCode.ControlChange,  // muteCode
+                MidiCommandCode.ControlChange,  // recordCode
+                MidiCommandCode.ControlChange   // subFaderCode
+            ),
+            new FaderDef(
+                false,   // delta
+                127f,    // range
+                1,      // channel
+                true,   // selectPresent
+                true,   // mutePresent
+                true,  // recordPresent
+                false, // subFaderPresent
+                1,      // faderOffset
+                64,     // selectOffset
+                51,     // muteOffset
+                20,     // recordOffset
+                0,      // subFaderOffset
+                MidiCommandCode.ControlChange,  // faderCode
+                MidiCommandCode.ControlChange,  // selectCode
+                MidiCommandCode.ControlChange,  // muteCode
+                MidiCommandCode.ControlChange,  // recordCode
+                MidiCommandCode.ControlChange   // subFaderCode
+            ),
+            new FaderDef(
+                false,   // delta
+                127f,    // range
+                1,      // channel
+                true,   // selectPresent
+                true,   // mutePresent
+                true,  // recordPresent
+                false, // subFaderPresent
+                1,      // faderOffset
+                64,     // selectOffset
+                20,     // muteOffset
+                21,     // recordOffset
+                0,      // subFaderOffset
+                MidiCommandCode.ControlChange,  // faderCode
+                MidiCommandCode.ControlChange,  // selectCode
+                MidiCommandCode.ControlChange,  // muteCode
+                MidiCommandCode.ControlChange,  // recordCode
+                MidiCommandCode.ControlChange   // subFaderCode
+            ),
+            new FaderDef(
+                false,   // delta
+                127f,    // range
+                1,      // channel
+                true,   // selectPresent
+                true,   // mutePresent
+                true,  // recordPresent
+                false,  // subFaderPresent
+                1,      // faderOffset
+                64,     // selectOffset
+                21,     // muteOffset
+                22,     // recordOffset
+                0,      // subFaderOffset
+                MidiCommandCode.ControlChange,  // faderCode
+                MidiCommandCode.ControlChange,  // selectCode
+                MidiCommandCode.ControlChange,  // muteCode
+                MidiCommandCode.ControlChange,  // recordCode
+                MidiCommandCode.ControlChange   // subFaderCode
+            )
+        };
+
+
+        public OP1(MidiDevice midiDev) : base(midiDev)
         {
-            faders = new List<Fader>
-            {
-                new Fader(this, 0, FirstFader),
-                new Fader(this, 1, SecondFader),
-                new Fader(this, 2, ThirdFader),
-                new Fader(this, 3, FourthFader)
-            };
-        }
-
-        public override void InitButtons()
-        {
-            buttons = new List<Button>
-            {
-                new Button(ref midiOut, ButtonType.MediaPlay, 39, true),
-                new Button(ref midiOut, ButtonType.MediaStop, 40, false),
-                new Button(ref midiOut, ButtonType.MediaNext, 16, true),
-                new Button(ref midiOut, ButtonType.MediaPrevious, 15, true)
-            };
-
-            // is this still needed?
-            buttonsMappingTable = new Hashtable();
-
-            foreach (var button in buttons)
-            {
-                buttonsMappingTable.Add(button.controller, button);
-            }
+            
         }
     }
 }

--- a/NK2Tray/XtouchMini.cs
+++ b/NK2Tray/XtouchMini.cs
@@ -6,160 +6,106 @@ using System.Collections;
 
 namespace NK2Tray
 {
-    public class XtouchMini : MidiDevice
+    public class XtouchMini : MidiDeviceTemplate
     {
-        public override string SearchString => "x-touch mini";
-        public override FaderDef DefaultFaderDef => new FaderDef(
-            true,  // delta
-            64f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            false, // recordPresent
-            false, // subFaderPresent
-            16,    // faderOffset
-            32,    // selectOffset
-            38,    // muteOffset
-            0,     // recordOffset
-            0,     // subFaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.NoteOn,        // selectCode
-            MidiCommandCode.NoteOn,        // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
+        public override bool hasLights => true;
+        public override int lightCount => 128;
+        public override MidiCommandCode lightMessageType => MidiCommandCode.NoteOn;
+        public override bool hasVolumeIndicator => true;
 
-        public FaderDef FirstTwoFaderDef => new FaderDef(
-            true,  // delta
-            64f,   // range
-            1,     // channel
-            true,  // selectPresent
-            true,  // mutePresent
-            false, // recordPresent
-            false, // subFaderPresent
-            16,    // faderOffset
-            32,    // selectOffset
-            89,    // muteOffset
-            0,     // recordOffset
-            0,     // subFaderOffset
-            MidiCommandCode.ControlChange, // faderCode
-            MidiCommandCode.NoteOn,        // selectCode
-            MidiCommandCode.NoteOn,        // muteCode
-            MidiCommandCode.ControlChange, // recordCode
-            MidiCommandCode.ControlChange  // subFaderCode
-        );
+        public override int fadersCount => 9;
 
-        public FaderDef MasterFaderDef => new FaderDef(
-            false,  // delta
-            16256f, // range
-            1,      // channel
-            true,   // selectPresent
-            true,   // mutePresent
-            false,  // recordPresent
-            false,  // subFaderPresent
-            0,      // faderOffset
-            76,     // selectOffset
-            77,     // muteOffset
-            0,      // recordOffset
-            0,      // subFaderOffset
-            MidiCommandCode.PitchWheelChange, // faderCode
-            MidiCommandCode.NoteOn,           // selectCode
-            MidiCommandCode.NoteOn,           // muteCode
-            MidiCommandCode.ControlChange,    // recordCode
-            MidiCommandCode.ControlChange,    // subFaderCode
-            9      // faderChannelOverride
-        );
-
-        public XtouchMini(AudioDevice audioDev)
+        public override Button[] buttons => new Button[]
         {
-            audioDevices = audioDev;
-            FindMidiIn();
-            FindMidiOut();
-            if (Found)
-            {
-                ResetAllLights();
-                InitFaders();
-                InitButtons();
-                LoadAssignments();
-                ListenForMidi();
-            }
+            new Button(midiDevice, ButtonType.MediaPrevious, 91, true, MidiCommandCode.NoteOn),
+            new Button(midiDevice, ButtonType.MediaNext,     92, true, MidiCommandCode.NoteOn),
+            new Button(midiDevice, ButtonType.MediaStop,     93, false, MidiCommandCode.NoteOn),
+            new Button(midiDevice, ButtonType.MediaPlay,     94, true, MidiCommandCode.NoteOn),
+            new Button(midiDevice, ButtonType.MediaRecord,   95, false, MidiCommandCode.NoteOn)
+        };
+
+        //public override string SearchString => "x-touch mini";
+
+        public override FaderDef[] faderDefs => new FaderDef[]{
+            new FaderDef( //Normal
+                true,  // delta
+                64f,   // range
+                1,     // channel
+                true,  // selectPresent
+                true,  // mutePresent
+                false, // recordPresent
+                false, // subFaderPresent
+                16,    // faderOffset
+                32,    // selectOffset
+                38,    // muteOffset
+                0,     // recordOffset
+                0,     // subFaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.NoteOn,        // selectCode
+                MidiCommandCode.NoteOn,        // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            ),
+            new FaderDef( //First two
+                true,  // delta
+                64f,   // range
+                1,     // channel
+                true,  // selectPresent
+                true,  // mutePresent
+                false, // recordPresent
+                false, // subFaderPresent
+                16,    // faderOffset
+                32,    // selectOffset
+                89,    // muteOffset
+                0,     // recordOffset
+                0,     // subFaderOffset
+                MidiCommandCode.ControlChange, // faderCode
+                MidiCommandCode.NoteOn,        // selectCode
+                MidiCommandCode.NoteOn,        // muteCode
+                MidiCommandCode.ControlChange, // recordCode
+                MidiCommandCode.ControlChange  // subFaderCode
+            ),
+            new FaderDef( //Master
+                false,  // delta
+                16256f, // range
+                1,      // channel
+                true,   // selectPresent
+                true,   // mutePresent
+                false,  // recordPresent
+                false,  // subFaderPresent
+                0,      // faderOffset
+                76,     // selectOffset
+                77,     // muteOffset
+                0,      // recordOffset
+                0,      // subFaderOffset
+                MidiCommandCode.PitchWheelChange, // faderCode
+                MidiCommandCode.NoteOn,           // selectCode
+                MidiCommandCode.NoteOn,           // muteCode
+                MidiCommandCode.ControlChange,    // recordCode
+                MidiCommandCode.ControlChange,    // subFaderCode
+                9      // faderChannelOverride
+            )
+        };
+
+        public XtouchMini(MidiDevice midiDev) : base(midiDev)
+        {
+
         }
 
-        public override void SetVolumeIndicator(int faderNum, float level)
+        public override void ResetSuppLights(MidiOut midiOut)
         {
-            if (level >= 0)
-            {
-                var usedLevel = level;
-                var fader = faders[faderNum];
-
-                if (fader.faderDef.delta)
-                {
-                    var nearestStep = fader.steps.Select((x, i) => new { Index = i, Distance = Math.Abs(level - x) }).OrderBy(x => x.Distance).First().Index;
-                    usedLevel = (float)nearestStep / (fader.steps.Length - 1);
-                }
-
-                var val = (int)Math.Round(usedLevel * 12) + 1 + 16 * 2;
-
-                Console.WriteLine($@"Setting fader {fader} display to {usedLevel} ({val})");
-                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(faderNum + 48), val).GetAsShortMessage());
-            }
-            else
-                midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)(faderNum + 48), 0).GetAsShortMessage());
-        }
-
-        public override void ResetAllLights()
-        {
-
             foreach (var i in Enumerable.Range(48, 8))
                 midiOut.Send(new ControlChangeEvent(0, 1, (MidiController)i, 0).GetAsShortMessage());
 
-
-            foreach (var i in Enumerable.Range(0, 128))
-                midiOut.Send(new NoteOnEvent(0, 1, i, 0, 0).GetAsShortMessage());
         }
 
-        public override void SetLight(int controller, bool state)
-        {
-            midiOut.Send(new NoteOnEvent(0, 1, controller, state ? 127 : 0, 0).GetAsShortMessage());
-        }
-
-        public override void InitFaders()
-        {
-            faders = new List<Fader>();
-            
-            foreach (var i in Enumerable.Range(0, 9))
-            {
-                Fader fader = new Fader(this, i, SelectFaderDef(i));
-                fader.ResetLights();
-                faders.Add(fader);
-            }
-        }
-
-        public FaderDef SelectFaderDef(int faderNum)
+        public override int SelectFaderDef(int faderNum)
         {
             if (faderNum < 2)
-                return FirstTwoFaderDef;
+                return 1; // First two
             else if (faderNum == 8)
-                return MasterFaderDef;
-            else
-                return DefaultFaderDef;
-        }
-
-        public override void InitButtons()
-        {
-            buttons = new List<Button>();
-
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPrevious, 91, true,  MidiCommandCode.NoteOn));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaNext,     92, true,  MidiCommandCode.NoteOn));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaStop,     93, false, MidiCommandCode.NoteOn));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaPlay,     94, true,  MidiCommandCode.NoteOn));
-            buttons.Add(new Button(ref midiOut,  ButtonType.MediaRecord,   95, false, MidiCommandCode.NoteOn));
-
-            buttonsMappingTable = new Hashtable();
-            foreach (var button in buttons)
-            {
-                buttonsMappingTable.Add(button.controller, button);
-            }
+                return 2; //Master
+            return 0;
         }
     }
 }


### PR DESCRIPTION
This pull includes a complete rework of the MidiDevice to make adding new devices easier, and new menus to choose input device, output device (#100) and device type:
![image](https://user-images.githubusercontent.com/21125429/120680533-b542e580-c49a-11eb-9360-5ddfa863885d.png)
![image](https://user-images.githubusercontent.com/21125429/120680617-cdb30000-c49a-11eb-8916-52e447a8be0d.png)

With the rework it will be way easier to implement fader feedback, volume meters... in the future
Still need to be done: better implementation of Midi device openning/closing to handle hotplug,... and avoid crashing.

Warning: I only tested this with my NK2, but no other device!